### PR TITLE
Update docstring for community_template in example-config.yaml

### DIFF
--- a/example-config.yaml
+++ b/example-config.yaml
@@ -80,7 +80,7 @@ bridge:
     # On startup, the bridge will try to create these communities, add all of the specific user's
     # portals to the community, and invite the Matrix user to it.
     # (Note that, by default, non-admins might not have your homeserver's permission to create
-    #  communities.)
+    #  communities. You should set `enable_group_creation: true` in homeserver.yaml to fix this.)
     # {{.Localpart}} is the MXID localpart and {{.Server}} is the MXID server part of the user.
     community_template: whatsapp_{{.Localpart}}={{.Server}}
 


### PR DESCRIPTION
The setting in homeserver.yaml that is alluded to is not obvious to new users, since "communities" are called "groups" in homeserver.yaml parlance.