### PR TITLE
Track "active" WhatsApp users and implement blocking when reaching the limit

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,12 @@ type Config struct {
 			Avatar      string `yaml:"avatar"`
 		} `yaml:"bot"`
 
+		Limits struct {
+			MaxPuppetLimit      uint `yaml:"max_puppet_limit"`
+			MinPuppetActiveDays uint `yaml:"min_puppet_activity_days"`
+			BlockOnLimitReached bool `yaml:"block_on_limit_reached"`
+		} `yaml:"limits"`
+
 		ASToken string `yaml:"as_token"`
 		HSToken string `yaml:"hs_token"`
 	} `yaml:"appservice"`
@@ -93,6 +99,9 @@ func (config *Config) CanDoublePuppet(userID id.UserID) bool {
 func (config *Config) setDefaults() {
 	config.AppService.Database.MaxOpenConns = 20
 	config.AppService.Database.MaxIdleConns = 2
+	config.AppService.Limits.MaxPuppetLimit = 0
+	config.AppService.Limits.MinPuppetActiveDays = 0
+	config.AppService.Limits.BlockOnLimitReached = false
 	config.WhatsApp.OSName = "Mautrix-WhatsApp bridge"
 	config.WhatsApp.BrowserName = "mx-wa"
 	config.Bridge.setDefaults()

--- a/config/config.go
+++ b/config/config.go
@@ -61,9 +61,10 @@ type Config struct {
 		} `yaml:"bot"`
 
 		Limits struct {
-			MaxPuppetLimit      uint `yaml:"max_puppet_limit"`
-			MinPuppetActiveDays uint `yaml:"min_puppet_activity_days"`
-			BlockOnLimitReached bool `yaml:"block_on_limit_reached"`
+			MaxPuppetLimit       uint `yaml:"max_puppet_limit"`
+			MinPuppetActiveDays  uint `yaml:"min_puppet_activity_days"`
+			PuppetInactivityDays uint `yaml:"puppet_inactivity_days"`
+			BlockOnLimitReached  bool `yaml:"block_on_limit_reached"`
 		} `yaml:"limits"`
 
 		ASToken string `yaml:"as_token"`

--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,7 @@ func (config *Config) setDefaults() {
 	config.AppService.Database.MaxIdleConns = 2
 	config.AppService.Limits.MaxPuppetLimit = 0
 	config.AppService.Limits.MinPuppetActiveDays = 0
+	config.AppService.Limits.PuppetInactivityDays = 30
 	config.AppService.Limits.BlockOnLimitReached = false
 	config.WhatsApp.OSName = "Mautrix-WhatsApp bridge"
 	config.WhatsApp.BrowserName = "mx-wa"

--- a/database/puppet.go
+++ b/database/puppet.go
@@ -42,7 +42,7 @@ func (pq *PuppetQuery) New() *Puppet {
 }
 
 func (pq *PuppetQuery) GetAll() (puppets []*Puppet) {
-	rows, err := pq.db.Query("SELECT jid, avatar, avatar_url, displayname, name_quality, custom_mxid, access_token, next_batch, enable_presence, enable_receipts FROM puppet")
+	rows, err := pq.db.Query("SELECT jid, avatar, avatar_url, displayname, name_quality, custom_mxid, access_token, next_batch, enable_presence, enable_receipts, first_activity_ts, last_activity_ts FROM puppet")
 	if err != nil || rows == nil {
 		return nil
 	}
@@ -54,7 +54,7 @@ func (pq *PuppetQuery) GetAll() (puppets []*Puppet) {
 }
 
 func (pq *PuppetQuery) Get(jid whatsapp.JID) *Puppet {
-	row := pq.db.QueryRow("SELECT jid, avatar, avatar_url, displayname, name_quality, custom_mxid, access_token, next_batch, enable_presence, enable_receipts FROM puppet WHERE jid=$1", jid)
+	row := pq.db.QueryRow("SELECT jid, avatar, avatar_url, displayname, name_quality, custom_mxid, access_token, next_batch, enable_presence, enable_receipts, first_activity_ts, last_activity_ts FROM puppet WHERE jid=$1", jid)
 	if row == nil {
 		return nil
 	}
@@ -62,7 +62,7 @@ func (pq *PuppetQuery) Get(jid whatsapp.JID) *Puppet {
 }
 
 func (pq *PuppetQuery) GetByCustomMXID(mxid id.UserID) *Puppet {
-	row := pq.db.QueryRow("SELECT jid, avatar, avatar_url, displayname, name_quality, custom_mxid, access_token, next_batch, enable_presence, enable_receipts FROM puppet WHERE custom_mxid=$1", mxid)
+	row := pq.db.QueryRow("SELECT jid, avatar, avatar_url, displayname, name_quality, custom_mxid, access_token, next_batch, enable_presence, enable_receipts, first_activity_ts, last_activity_ts FROM puppet WHERE custom_mxid=$1", mxid)
 	if row == nil {
 		return nil
 	}
@@ -70,7 +70,7 @@ func (pq *PuppetQuery) GetByCustomMXID(mxid id.UserID) *Puppet {
 }
 
 func (pq *PuppetQuery) GetAllWithCustomMXID() (puppets []*Puppet) {
-	rows, err := pq.db.Query("SELECT jid, avatar, avatar_url, displayname, name_quality, custom_mxid, access_token, next_batch, enable_presence, enable_receipts FROM puppet WHERE custom_mxid<>''")
+	rows, err := pq.db.Query("SELECT jid, avatar, avatar_url, displayname, name_quality, custom_mxid, access_token, next_batch, enable_presence, enable_receipts, first_activity_ts, last_activity_ts FROM puppet WHERE custom_mxid<>''")
 	if err != nil || rows == nil {
 		return nil
 	}
@@ -91,18 +91,20 @@ type Puppet struct {
 	Displayname string
 	NameQuality int8
 
-	CustomMXID     id.UserID
-	AccessToken    string
-	NextBatch      string
-	EnablePresence bool
-	EnableReceipts bool
+	CustomMXID      id.UserID
+	AccessToken     string
+	NextBatch       string
+	EnablePresence  bool
+	EnableReceipts  bool
+	FirstActivityTs int64
+	LastActivityTs  int64
 }
 
 func (puppet *Puppet) Scan(row Scannable) *Puppet {
 	var displayname, avatar, avatarURL, customMXID, accessToken, nextBatch sql.NullString
-	var quality sql.NullInt64
+	var quality, firstActivityTs, lastActivityTs sql.NullInt64
 	var enablePresence, enableReceipts sql.NullBool
-	err := row.Scan(&puppet.JID, &avatar, &avatarURL, &displayname, &quality, &customMXID, &accessToken, &nextBatch, &enablePresence, &enableReceipts)
+	err := row.Scan(&puppet.JID, &avatar, &avatarURL, &displayname, &quality, &customMXID, &accessToken, &nextBatch, &enablePresence, &enableReceipts, &firstActivityTs, &lastActivityTs)
 	if err != nil {
 		if err != sql.ErrNoRows {
 			puppet.log.Errorln("Database scan failed:", err)
@@ -118,6 +120,8 @@ func (puppet *Puppet) Scan(row Scannable) *Puppet {
 	puppet.NextBatch = nextBatch.String
 	puppet.EnablePresence = enablePresence.Bool
 	puppet.EnableReceipts = enableReceipts.Bool
+	puppet.FirstActivityTs = firstActivityTs.Int64
+	puppet.LastActivityTs = lastActivityTs.Int64
 	return puppet
 }
 
@@ -134,5 +138,21 @@ func (puppet *Puppet) Update() {
 		puppet.Displayname, puppet.NameQuality, puppet.Avatar, puppet.AvatarURL.String(), puppet.CustomMXID, puppet.AccessToken, puppet.NextBatch, puppet.EnablePresence, puppet.EnableReceipts, puppet.JID)
 	if err != nil {
 		puppet.log.Warnfln("Failed to update %s->%s: %v", puppet.JID, err)
+	}
+}
+
+func (puppet *Puppet) UpdateActivityTs(ts uint64) {
+	puppet.LastActivityTs = int64(ts)
+	_, err := puppet.db.Exec("UPDATE puppet SET last_activity_ts=$1 WHERE jid=$2", puppet.LastActivityTs, puppet.JID)
+	if err != nil {
+		puppet.log.Warnfln("Failed to update last_activity_ts %s->%s: %v", puppet.JID, err)
+	}
+
+	if puppet.FirstActivityTs == 0 {
+		puppet.FirstActivityTs = puppet.LastActivityTs
+		_, err = puppet.db.Exec("UPDATE puppet SET first_activity_ts=$1 WHERE jid=$2 AND first_activity_ts is NULL", puppet.FirstActivityTs, puppet.JID)
+		if err != nil {
+			puppet.log.Warnfln("Failed to update first_activity_ts %s->%s: %v", puppet.JID, err)
+		}
 	}
 }

--- a/database/upgrades/2021-07-07-puppet-activity.go
+++ b/database/upgrades/2021-07-07-puppet-activity.go
@@ -1,0 +1,16 @@
+package upgrades
+
+import (
+	"database/sql"
+)
+
+func init() {
+	upgrades[21] = upgrade{"Add ", func(tx *sql.Tx, ctx context) error {
+		_, err := tx.Exec(`ALTER TABLE puppet ADD COLUMN first_activity_ts BIGINT`)
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(`ALTER TABLE puppet ADD COLUMN last_activity_ts BIGINT`)
+		return err
+	}}
+}

--- a/database/upgrades/upgrades.go
+++ b/database/upgrades/upgrades.go
@@ -39,7 +39,7 @@ type upgrade struct {
 	fn      upgradeFunc
 }
 
-const NumberOfUpgrades = 21
+const NumberOfUpgrades = 22
 
 var upgrades [NumberOfUpgrades]upgrade
 

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -56,10 +56,9 @@ appservice:
 
     # Limit usage of the bridge
     limits:
-        # The maximum number of bridge puppets
+        # The maximum number of bridge puppets that can be "active" before the limit is reached
         max_puppet_limit: 0
-        # The minimum amount of days a puppet must be active for before they are considered part of the limit.
-        # Activity is measured from 
+        # The minimum amount of days a puppet must be active for before they are considered "active".
         min_puppet_activity_days: 0
         # Should the bridge block traffic when a limit has been reached
         block_on_limit_reached: false

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -60,6 +60,8 @@ appservice:
         max_puppet_limit: 0
         # The minimum amount of days a puppet must be active for before they are considered "active".
         min_puppet_activity_days: 0
+        # The number of days after a puppets last activity where they are considered inactive again.
+        puppet_inactivity_days: 30
         # Should the bridge block traffic when a limit has been reached
         block_on_limit_reached: false
 

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -54,6 +54,16 @@ appservice:
     as_token: "This value is generated when generating the registration"
     hs_token: "This value is generated when generating the registration"
 
+    # Limit usage of the bridge
+    limits:
+        # The maximum number of bridge puppets
+        max_puppet_limit: 0
+        # The minimum amount of days a puppet must be active for before they are considered part of the limit.
+        # Activity is measured from 
+        min_puppet_activity_days: 0
+        # Should the bridge block traffic when a limit has been reached
+        block_on_limit_reached: false
+
 metrics:
     # Whether or not to enable prometheus metrics
     enabled: false

--- a/main.go
+++ b/main.go
@@ -283,6 +283,7 @@ func (mh *Bridge) UpdateActivePuppetCount() {
 	mh.Log.Debugfln("Updating active puppet count")
 
 	var minActivityTime = int64(ONE_DAY_S * mh.Config.AppService.Limits.MinPuppetActiveDays)
+	var maxActivityTime = int64(ONE_DAY_S * mh.Config.AppService.Limits.PuppetInactivityDays)
 	var activePuppetCount uint
 	var firstActivityTs, lastActivityTs int64
 
@@ -294,7 +295,8 @@ func (mh *Bridge) UpdateActivePuppetCount() {
 		for rows.Next() {
 			rows.Scan(&firstActivityTs, &lastActivityTs)
 			var secondsOfActivity = lastActivityTs - firstActivityTs
-			if secondsOfActivity > minActivityTime {
+			var isInactive = time.Now().Unix()-lastActivityTs > maxActivityTime
+			if !isInactive && secondsOfActivity > minActivityTime && secondsOfActivity < maxActivityTime {
 				activePuppetCount++
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -280,10 +280,6 @@ func (bridge *Bridge) Init() {
 }
 
 func (mh *Bridge) UpdateActivePuppetCount() {
-	if mh.Config.AppService.Limits.MinPuppetActiveDays == 0 {
-		// We only care about this when we're actively tracking
-		return
-	}
 	mh.Log.Debugfln("Updating active puppet count")
 
 	var minActivityTime = int64(ONE_DAY_S * mh.Config.AppService.Limits.MinPuppetActiveDays)

--- a/metrics.go
+++ b/metrics.go
@@ -36,9 +36,10 @@ import (
 )
 
 type MetricsHandler struct {
-	db     *database.Database
-	server *http.Server
-	log    log.Logger
+	db             *database.Database
+	server         *http.Server
+	log            log.Logger
+	puppetActivity *PuppetActivity
 
 	running      bool
 	ctx          context.Context
@@ -50,6 +51,8 @@ type MetricsHandler struct {
 	countCollection         prometheus.Histogram
 	disconnections          *prometheus.CounterVec
 	puppetCount             prometheus.Gauge
+	activePuppetCount       prometheus.Gauge
+	bridgeBlocked           prometheus.Gauge
 	userCount               prometheus.Gauge
 	messageCount            prometheus.Gauge
 	portalCount             *prometheus.GaugeVec
@@ -67,7 +70,7 @@ type MetricsHandler struct {
 	bufferLength    *prometheus.GaugeVec
 }
 
-func NewMetricsHandler(address string, log log.Logger, db *database.Database) *MetricsHandler {
+func NewMetricsHandler(address string, log log.Logger, db *database.Database, puppetActivity *PuppetActivity) *MetricsHandler {
 	portalCount := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "whatsapp_portals_total",
 		Help: "Number of portal rooms on Matrix",
@@ -77,7 +80,6 @@ func NewMetricsHandler(address string, log log.Logger, db *database.Database) *M
 		server:  &http.Server{Addr: address, Handler: promhttp.Handler()},
 		log:     log,
 		running: false,
-
 		matrixEventHandling: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name: "matrix_event",
 			Help: "Time spent processing Matrix events",
@@ -102,6 +104,14 @@ func NewMetricsHandler(address string, log log.Logger, db *database.Database) *M
 		puppetCount: promauto.NewGauge(prometheus.GaugeOpts{
 			Name: "whatsapp_puppets_total",
 			Help: "Number of WhatsApp users bridged into Matrix",
+		}),
+		activePuppetCount: promauto.NewGauge(prometheus.GaugeOpts{
+			Name: "whatsapp_active_puppets_total",
+			Help: "Number of active WhatsApp users bridged into Matrix",
+		}),
+		bridgeBlocked: promauto.NewGauge(prometheus.GaugeOpts{
+			Name: "whatsapp_bridge_blocked",
+			Help: "Is the bridge currently blocking messages",
 		}),
 		userCount: promauto.NewGauge(prometheus.GaugeOpts{
 			Name: "whatsapp_users_total",
@@ -236,6 +246,13 @@ func (mh *MetricsHandler) updateStats() {
 		mh.log.Warnln("Failed to scan number of puppets:", err)
 	} else {
 		mh.puppetCount.Set(float64(puppetCount))
+	}
+
+	mh.activePuppetCount.Set(float64(mh.puppetActivity.currentUserCount))
+	if mh.puppetActivity.isBlocked {
+		mh.bridgeBlocked.Set(1)
+	} else {
+		mh.bridgeBlocked.Set(0)
 	}
 
 	var userCount int

--- a/metrics.go
+++ b/metrics.go
@@ -76,10 +76,11 @@ func NewMetricsHandler(address string, log log.Logger, db *database.Database, pu
 		Help: "Number of portal rooms on Matrix",
 	}, []string{"type", "encrypted"})
 	return &MetricsHandler{
-		db:      db,
-		server:  &http.Server{Addr: address, Handler: promhttp.Handler()},
-		log:     log,
-		running: false,
+		db:             db,
+		server:         &http.Server{Addr: address, Handler: promhttp.Handler()},
+		log:            log,
+		running:        false,
+		puppetActivity: puppetActivity,
 		matrixEventHandling: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name: "matrix_event",
 			Help: "Time spent processing Matrix events",

--- a/portal.go
+++ b/portal.go
@@ -316,9 +316,6 @@ func (portal *Portal) handleMessage(msg PortalMessage, isBackfill bool) {
 	if triedToHandle && trackMessageCallback != nil {
 		trackMessageCallback()
 	}
-	sender := portal.bridge.GetPuppetByJID(msg.source.JID)
-	sender.UpdateActivityTs(msg.timestamp)
-	portal.bridge.UpdateActivePuppetCount()
 }
 
 func (portal *Portal) isRecentlyHandled(id whatsapp.MessageID) bool {
@@ -1400,6 +1397,9 @@ func (portal *Portal) HandleTextMessage(source *User, message whatsapp.TextMessa
 	} else {
 		portal.finishHandling(source, message.Info.Source, resp.EventID)
 	}
+	sender := portal.bridge.GetPuppetByJID(message.Info.SenderJid)
+	sender.UpdateActivityTs(message.Info.Timestamp)
+	portal.bridge.UpdateActivePuppetCount()
 	return true
 }
 

--- a/puppet.go
+++ b/puppet.go
@@ -32,6 +32,11 @@ import (
 	"maunium.net/go/mautrix-whatsapp/database"
 )
 
+type PuppetActivity struct {
+	currentUserCount uint
+	isBlocked        bool
+}
+
 var userIDRegex *regexp.Regexp
 
 func (bridge *Bridge) ParsePuppetMXID(mxid id.UserID) (whatsapp.JID, bool) {


### PR DESCRIPTION
This PR intends to do two things:
- Store and track activity metrics for whatsapp users, using a metric of minimum days before they are considered active.
- Block the bridge from sending/receiving traffic when the cap has been reached for active users. 