### PR TITLE
Help text of login-matrix: Remove trailing apostrophe

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -902,7 +902,7 @@ func (handler *CommandHandler) CommandPM(ce *CommandEvent) {
 	ce.Reply("Created portal room and invited you to it.")
 }
 
-const cmdLoginMatrixHelp = `login-matrix <_access token_> - Replace your WhatsApp account's Matrix puppet with your real Matrix account.'`
+const cmdLoginMatrixHelp = `login-matrix <_access token_> - Replace your WhatsApp account's Matrix puppet with your real Matrix account.`
 
 func (handler *CommandHandler) CommandLoginMatrix(ce *CommandEvent) {
 	if len(ce.Args) == 0 {


### PR DESCRIPTION
![Screenshot 2021-09-13 at 14-35-00 Element WhatsApp bridge bot](https://user-images.githubusercontent.com/10872136/133084462-98bee41b-36bd-41ed-b942-936282963a59.png)

Remove the apostrophe that only the help text of "login-matrix" is ending with.