### PR TITLE
Fix DBMS migration

### DIFF
--- a/database/migrate.go
+++ b/database/migrate.go
@@ -156,4 +156,45 @@ func Migrate(old *Database, new *Database) {
 	if err != nil {
 		panic(err)
 	}
+	// Migrate whatsmeow tables.
+	err = migrateTable(old, new, "whatsmeow_device", "jid", "registration_id", "noise_key", "identity_key", "signed_pre_key", "signed_pre_key_id", "signed_pre_key_sig", "adv_key", "adv_details", "adv_account_sig", "adv_device_sig", "platform", "business_name", "push_name")
+	if err != nil {
+		panic(err)
+	}
+	err = migrateTable(old, new, "whatsmeow_identity_keys", "our_jid", "their_id", "identity")
+	if err != nil {
+		panic(err)
+	}
+	err = migrateTable(old, new, "whatsmeow_pre_keys", "jid", "key_id", "key", "uploaded")
+	if err != nil {
+		panic(err)
+	}
+	err = migrateTable(old, new, "whatsmeow_sessions", "our_jid", "their_id", "session")
+	if err != nil {
+		panic(err)
+	}
+	err = migrateTable(old, new, "whatsmeow_sender_keys", "our_jid", "chat_id", "sender_id", "sender_key")
+	if err != nil {
+		panic(err)
+	}
+	err = migrateTable(old, new, "whatsmeow_app_state_sync_keys", "jid", "key_id", "key_data", "timestamp", "fingerprint")
+	if err != nil {
+		panic(err)
+	}
+	err = migrateTable(old, new, "whatsmeow_app_state_version", "jid", "name", "version", "hash")
+	if err != nil {
+		panic(err)
+	}
+	err = migrateTable(old, new, "whatsmeow_app_state_mutation_macs", "jid", "name", "version", "index_mac", "value_mac")
+	if err != nil {
+		panic(err)
+	}
+	err = migrateTable(old, new, "whatsmeow_contacts", "our_jid", "their_jid", "first_name", "full_name", "push_name", "business_name")
+	if err != nil {
+		panic(err)
+	}
+	err = migrateTable(old, new, "whatsmeow_chat_settings", "our_jid", "chat_jid", "muted_until", "pinned", "archived")
+	if err != nil {
+		panic(err)
+	}
 }

--- a/database/migrate.go
+++ b/database/migrate.go
@@ -92,23 +92,19 @@ func migrateTable(old *Database, new *Database, table string, columns ...string)
 }
 
 func Migrate(old *Database, new *Database) {
-	err := migrateTable(old, new, "portal", "jid", "receiver", "mxid", "name", "topic", "avatar", "avatar_url", "encrypted")
+	err := migrateTable(old, new, "portal", "jid", "receiver", "mxid", "name", "topic", "avatar", "avatar_url", "encrypted", "first_event_id", "next_batch_id", "relay_user_id")
 	if err != nil {
 		panic(err)
 	}
-	err = migrateTable(old, new, "user", "mxid", "jid", "management_room", "client_id", "client_token", "server_token", "enc_key", "mac_key", "last_connection")
+	err = migrateTable(old, new, "user", "mxid", "management_room", "username", "agent", "device")
 	if err != nil {
 		panic(err)
 	}
-	err = migrateTable(old, new, "puppet", "jid", "avatar", "displayname", "name_quality", "custom_mxid", "access_token", "next_batch", "avatar_url", "enable_presence", "enable_receipts")
+	err = migrateTable(old, new, "puppet", "username", "avatar", "displayname", "name_quality", "custom_mxid", "access_token", "next_batch", "avatar_url", "enable_presence", "enable_receipts")
 	if err != nil {
 		panic(err)
 	}
-	err = migrateTable(old, new, "user_portal", "user_jid", "portal_jid", "portal_receiver", "in_community")
-	if err != nil {
-		panic(err)
-	}
-	err = migrateTable(old, new, "message", "chat_jid", "chat_receiver", "jid", "mxid", "sender", "timestamp", "sent")
+	err = migrateTable(old, new, "message", "chat_jid", "chat_receiver", "jid", "mxid", "sender", "timestamp", "sent", "decryption_error")
 	if err != nil {
 		panic(err)
 	}
@@ -149,6 +145,14 @@ func Migrate(old *Database, new *Database) {
 		panic(err)
 	}
 	err = migrateTable(old, new, "crypto_megolm_outbound_session", "account_id", "room_id", "session_id", "session", "shared", "max_messages", "message_count", "max_age", "created_at", "last_used")
+	if err != nil {
+		panic(err)
+	}
+	err = migrateTable(old, new, "crypto_cross_signing_keys", "user_id", "usage", "key")
+	if err != nil {
+		panic(err)
+	}
+	err = migrateTable(old, new, "crypto_cross_signing_signatures", "signed_user_id", "signed_key", "signer_user_id", "signer_key", "signature")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This fixes the dbms migration by using the latest set of columns.

FYI, that's the latest version of the SQL scheme:

<details>

```
CREATE TABLE portal (
  jid VARCHAR(255), 
  receiver VARCHAR(255), 
  mxid VARCHAR(255) UNIQUE, 
  name VARCHAR(255) NOT NULL, 
  topic VARCHAR(255) NOT NULL, 
  avatar VARCHAR(255) NOT NULL, 
  avatar_url VARCHAR(255), 
  encrypted BOOLEAN NOT NULL DEFAULT false, 
  first_event_id TEXT NOT NULL DEFAULT '', 
  next_batch_id TEXT NOT NULL DEFAULT '', 
  relay_user_id TEXT, 
  PRIMARY KEY (jid, receiver)
);
CREATE TABLE puppet (
  username VARCHAR(255) PRIMARY KEY, 
  avatar VARCHAR(255), 
  displayname VARCHAR(255), 
  name_quality SMALLINT, 
  custom_mxid VARCHAR(255), 
  access_token VARCHAR(1023), 
  next_batch VARCHAR(255), 
  avatar_url VARCHAR(255), 
  enable_presence BOOLEAN NOT NULL DEFAULT true, 
  enable_receipts BOOLEAN NOT NULL DEFAULT true
);
CREATE TABLE mx_user_profile (
  room_id VARCHAR(255), 
  user_id VARCHAR(255), 
  membership VARCHAR(15) NOT NULL, 
  displayname TEXT, 
  avatar_url VARCHAR(255), 
  PRIMARY KEY (room_id, user_id)
);
CREATE TABLE mx_room_state (
  room_id VARCHAR(255) PRIMARY KEY, 
  power_levels TEXT
);
CREATE TABLE mx_registrations (
  user_id VARCHAR(255) PRIMARY KEY
);
CREATE TABLE crypto_message_index (
  sender_key CHAR(43), 
  session_id CHAR(43), 
  "index" INTEGER, 
  event_id VARCHAR(255) NOT NULL, 
  timestamp BIGINT NOT NULL, 
  PRIMARY KEY (sender_key, session_id, "index")
);
CREATE TABLE crypto_tracked_user (
  user_id VARCHAR(255) PRIMARY KEY
);
CREATE TABLE crypto_device (
  user_id VARCHAR(255), 
  device_id VARCHAR(255), 
  identity_key CHAR(43) NOT NULL, 
  signing_key CHAR(43) NOT NULL, 
  trust SMALLINT NOT NULL, 
  deleted BOOLEAN NOT NULL, 
  name VARCHAR(255) NOT NULL, 
  PRIMARY KEY (user_id, device_id)
);
CREATE TABLE crypto_account (
  account_id VARCHAR(255) NOT NULL, 
  device_id VARCHAR(255) NOT NULL, 
  shared BOOLEAN NOT NULL, 
  sync_token TEXT NOT NULL, 
  account bytea NOT NULL, 
  PRIMARY KEY (account_id)
);
CREATE TABLE crypto_olm_session (
  account_id VARCHAR(255) NOT NULL, 
  session_id CHAR(43) NOT NULL, 
  sender_key CHAR(43) NOT NULL, 
  session bytea NOT NULL, 
  created_at timestamp NOT NULL, 
  last_used timestamp NOT NULL, 
  PRIMARY KEY (account_id, session_id)
);
CREATE TABLE crypto_megolm_outbound_session (
  account_id VARCHAR(255) NOT NULL, 
  room_id VARCHAR(255) NOT NULL, 
  session_id CHAR(43) NOT NULL UNIQUE, 
  session bytea NOT NULL, 
  shared BOOLEAN NOT NULL, 
  max_messages INTEGER NOT NULL, 
  message_count INTEGER NOT NULL, 
  max_age BIGINT NOT NULL, 
  created_at timestamp NOT NULL, 
  last_used timestamp NOT NULL, 
  PRIMARY KEY (account_id, room_id)
);
CREATE TABLE crypto_megolm_inbound_session (
  account_id VARCHAR(255) NOT NULL, 
  session_id CHAR(43) NOT NULL, 
  sender_key CHAR(43) NOT NULL, 
  signing_key CHAR(43), 
  room_id VARCHAR(255) NOT NULL, 
  session BLOB, 
  forwarding_chains BLOB, 
  withheld_code VARCHAR(255), 
  withheld_reason TEXT, 
  PRIMARY KEY (account_id, session_id)
);
CREATE TABLE crypto_cross_signing_keys (
  user_id VARCHAR(255) NOT NULL, 
  usage VARCHAR(20) NOT NULL, 
  key CHAR(43) NOT NULL, 
  PRIMARY KEY (user_id, usage)
);
CREATE TABLE crypto_cross_signing_signatures (
  signed_user_id VARCHAR(255) NOT NULL, 
  signed_key VARCHAR(255) NOT NULL, 
  signer_user_id VARCHAR(255) NOT NULL, 
  signer_key VARCHAR(255) NOT NULL, 
  signature CHAR(88) NOT NULL, 
  PRIMARY KEY (
    signed_user_id, signed_key, signer_user_id, 
    signer_key
  )
);
CREATE TABLE message (
  chat_jid TEXT, 
  chat_receiver TEXT, 
  jid TEXT, 
  mxid TEXT NOT NULL UNIQUE, 
  sender TEXT NOT NULL, 
  timestamp BIGINT NOT NULL, 
  sent BOOLEAN NOT NULL, 
  decryption_error BOOLEAN NOT NULL DEFAULT false, 
  PRIMARY KEY (chat_jid, chat_receiver, jid), 
  FOREIGN KEY (chat_jid, chat_receiver) REFERENCES portal(jid, receiver) ON DELETE CASCADE
);
CREATE TABLE whatsmeow_device (
  jid TEXT PRIMARY KEY, 
  registration_id BIGINT NOT NULL CHECK (
    registration_id >= 0 
    AND registration_id < 4294967296
  ), 
  noise_key bytea NOT NULL CHECK (
    length(noise_key) = 32
  ), 
  identity_key bytea NOT NULL CHECK (
    length(identity_key) = 32
  ), 
  signed_pre_key bytea NOT NULL CHECK (
    length(signed_pre_key) = 32
  ), 
  signed_pre_key_id INTEGER NOT NULL CHECK (
    signed_pre_key_id >= 0 
    AND signed_pre_key_id < 16777216
  ), 
  signed_pre_key_sig bytea NOT NULL CHECK (
    length(signed_pre_key_sig) = 64
  ), 
  adv_key bytea NOT NULL, 
  adv_details bytea NOT NULL, 
  adv_account_sig bytea NOT NULL CHECK (
    length(adv_account_sig) = 64
  ), 
  adv_device_sig bytea NOT NULL CHECK (
    length(adv_device_sig) = 64
  ), 
  platform TEXT NOT NULL DEFAULT '', 
  business_name TEXT NOT NULL DEFAULT '', 
  push_name TEXT NOT NULL DEFAULT ''
);
CREATE TABLE whatsmeow_identity_keys (
  our_jid TEXT, 
  their_id TEXT, 
  identity bytea NOT NULL CHECK (
    length(identity) = 32
  ), 
  PRIMARY KEY (our_jid, their_id), 
  FOREIGN KEY (our_jid) REFERENCES whatsmeow_device(jid) ON DELETE CASCADE ON UPDATE CASCADE
);
CREATE TABLE whatsmeow_pre_keys (
  jid TEXT, 
  key_id INTEGER CHECK (
    key_id >= 0 
    AND key_id < 16777216
  ), 
  key bytea NOT NULL CHECK (
    length(key) = 32
  ), 
  uploaded BOOLEAN NOT NULL, 
  PRIMARY KEY (jid, key_id), 
  FOREIGN KEY (jid) REFERENCES whatsmeow_device(jid) ON DELETE CASCADE ON UPDATE CASCADE
);
CREATE TABLE whatsmeow_sessions (
  our_jid TEXT, 
  their_id TEXT, 
  session bytea, 
  PRIMARY KEY (our_jid, their_id), 
  FOREIGN KEY (our_jid) REFERENCES whatsmeow_device(jid) ON DELETE CASCADE ON UPDATE CASCADE
);
CREATE TABLE whatsmeow_sender_keys (
  our_jid TEXT, 
  chat_id TEXT, 
  sender_id TEXT, 
  sender_key bytea NOT NULL, 
  PRIMARY KEY (our_jid, chat_id, sender_id), 
  FOREIGN KEY (our_jid) REFERENCES whatsmeow_device(jid) ON DELETE CASCADE ON UPDATE CASCADE
);
CREATE TABLE whatsmeow_app_state_sync_keys (
  jid TEXT, 
  key_id bytea, 
  key_data bytea NOT NULL, 
  timestamp BIGINT NOT NULL, 
  fingerprint bytea NOT NULL, 
  PRIMARY KEY (jid, key_id), 
  FOREIGN KEY (jid) REFERENCES whatsmeow_device(jid) ON DELETE CASCADE ON UPDATE CASCADE
);
CREATE TABLE whatsmeow_app_state_version (
  jid TEXT, 
  name TEXT, 
  version BIGINT NOT NULL, 
  hash bytea NOT NULL CHECK (
    length(hash) = 128
  ), 
  PRIMARY KEY (jid, name), 
  FOREIGN KEY (jid) REFERENCES whatsmeow_device(jid) ON DELETE CASCADE ON UPDATE CASCADE
);
CREATE TABLE whatsmeow_app_state_mutation_macs (
  jid TEXT, 
  name TEXT, 
  version BIGINT, 
  index_mac bytea CHECK (
    length(index_mac) = 32
  ), 
  value_mac bytea NOT NULL CHECK (
    length(value_mac) = 32
  ), 
  PRIMARY KEY (jid, name, version, index_mac), 
  FOREIGN KEY (jid, name) REFERENCES whatsmeow_app_state_version(jid, name) ON DELETE CASCADE ON UPDATE CASCADE
);
CREATE TABLE whatsmeow_contacts (
  our_jid TEXT, 
  their_jid TEXT, 
  first_name TEXT, 
  full_name TEXT, 
  push_name TEXT, 
  business_name TEXT, 
  PRIMARY KEY (our_jid, their_jid), 
  FOREIGN KEY (our_jid) REFERENCES whatsmeow_device(jid) ON DELETE CASCADE ON UPDATE CASCADE
);
CREATE TABLE whatsmeow_chat_settings (
  our_jid TEXT, 
  chat_jid TEXT, 
  muted_until BIGINT NOT NULL DEFAULT 0, 
  pinned BOOLEAN NOT NULL DEFAULT false, 
  archived BOOLEAN NOT NULL DEFAULT false, 
  PRIMARY KEY (our_jid, chat_jid), 
  FOREIGN KEY (our_jid) REFERENCES whatsmeow_device(jid) ON DELETE CASCADE ON UPDATE CASCADE
);
CREATE TABLE IF NOT EXISTS "user" (
  mxid TEXT PRIMARY KEY, username TEXT UNIQUE, 
  agent SMALLINT, device SMALLINT, management_room TEXT
);
```

</details>

Does the group of `whatsmeow` tables also need to be migrated? I was unsure about that, but seems that it should be too. In terms of software engineering, would be better to have `whatsmeow` export its own `Migrate` function, but the most expedient solution would be to do the migration ourselves here. Thoughts?

Fixes #386.