### PR TITLE
clearer database uri example

### DIFF
--- a/example-config.yaml
+++ b/example-config.yaml
@@ -27,11 +27,11 @@ appservice:
         # The database type. "sqlite3" and "postgres" are supported.
         type: sqlite3
         # The database URI.
-        #   SQLite: File name is enough. For example, uri: mautrix-whatsapp.db
-        #           https://github.com/mattn/go-sqlite3#connection-string
-        #   Postgres: Connection string. For example, uri: postgres://user:password@host/database?sslmode=disable
-        #             To connect via Unix socket, use something like uri: postgres:///dbname?host=/var/run/postgresql
-        uri: mautrix-whatsapp.db
+        #   SQLite: File name is enough. https://github.com/mattn/go-sqlite3#connection-string
+        #   Postgres: Connection string. For example, postgres://user:password@host/database?sslmode=disable
+        #             To connect via Unix socket, use something like postgres:///dbname?host=/var/run/postgresql
+        uri: mautrix-whatsapp.db # for sqlite3
+        # uri: postgres://user:password@host/database?sslmode=disable # for postgres
         # Maximum number of connections. Mostly relevant for Postgres.
         max_open_conns: 20
         max_idle_conns: 2

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -27,9 +27,10 @@ appservice:
         # The database type. "sqlite3" and "postgres" are supported.
         type: sqlite3
         # The database URI.
-        #   SQLite: File name is enough. https://github.com/mattn/go-sqlite3#connection-string
-        #   Postgres: Connection string. For example, postgres://user:password@host/database?sslmode=disable
-        #             To connect via Unix socket, use something like postgres:///dbname?host=/var/run/postgresql
+        #   SQLite: File name is enough. For example, uri: mautrix-whatsapp.db
+        #           https://github.com/mattn/go-sqlite3#connection-string
+        #   Postgres: Connection string. For example, uri: postgres://user:password@host/database?sslmode=disable
+        #             To connect via Unix socket, use something like uri: postgres:///dbname?host=/var/run/postgresql
         uri: mautrix-whatsapp.db
         # Maximum number of connections. Mostly relevant for Postgres.
         max_open_conns: 20


### PR DESCRIPTION
I'm watching someone trying to configure this and they can't figure out whats wrong with their yaml:
```yaml
postgres://user:xxxxxx@localhost/synapse_db?sslmode=disable
uri: mautrix-whatsapp.db
```