### PR TITLE
feat Set RoomName-as-ContactFullName

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -29,8 +29,9 @@ import (
 )
 
 type BridgeConfig struct {
-	UsernameTemplate    string `yaml:"username_template"`
-	DisplaynameTemplate string `yaml:"displayname_template"`
+	UsernameTemplate         string `yaml:"username_template"`
+	DisplaynameTemplate      string `yaml:"displayname_template"`
+	SetRoomNameToContactName bool   `yaml:"set_room_name_to_contact_name"`
 
 	PersonalFilteringSpaces bool `yaml:"personal_filtering_spaces"`
 

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -96,6 +96,9 @@ bridge:
     displayname_template: "{{if .PushName}}{{.PushName}}{{else if .BusinessName}}{{.BusinessName}}{{else}}{{.JID}}{{end}} (WA)"
     # Should the bridge create a space for each logged-in user and add bridged rooms to it?
     personal_filtering_spaces: false
+    # portal names as contact's full name - since it is not recommended to set {{.FullName}} as the displayname of the puppet
+    # you can instead set the room name to be the contact's FullName
+    set_room_name_to_contact_name: false
     # Should the bridge send a read receipt from the bridge bot when a message has been sent to WhatsApp?
     delivery_receipts: false
     # Should incoming calls send a message to the Matrix room?

--- a/matrix.go
+++ b/matrix.go
@@ -176,7 +176,23 @@ func (mx *MatrixHandler) createPrivatePortalFromInvite(roomID id.RoomID, inviter
 	portal.Topic = PrivateChatTopic
 	_, _ = portal.MainIntent().SetRoomTopic(portal.MXID, portal.Topic)
 	if portal.bridge.Config.Bridge.PrivateChatPortalMeta {
-		portal.Name = puppet.Displayname
+		if portal.bridge.Config.Bridge.SetRoomNameToContactName {
+			contact, err := inviter.Client.Store.Contacts.GetContact(puppet.JID)
+			if err != nil {
+				puppet.log.Warnln("Failed to get contact info in createPrivatePortalFromInvite")
+			} else {
+				var newName string
+				if len(contact.FullName) > 0 {
+					newName = contact.FullName
+				} else {
+					// fall back to Display Name if FullName field is empty
+					newName = puppet.Displayname
+				}
+				portal.Name = newName
+			}
+		} else {
+			portal.Name = puppet.Displayname
+		}
 		portal.AvatarURL = puppet.AvatarURL
 		portal.Avatar = puppet.Avatar
 		_, _ = portal.MainIntent().SetRoomName(portal.MXID, portal.Name)

--- a/portal.go
+++ b/portal.go
@@ -991,7 +991,23 @@ func (portal *Portal) CreateMatrixRoom(user *User, groupInfo *types.GroupInfo, i
 		puppet := portal.bridge.GetPuppetByJID(portal.Key.JID)
 		puppet.SyncContact(user, true, "creating private chat portal")
 		if portal.bridge.Config.Bridge.PrivateChatPortalMeta {
-			portal.Name = puppet.Displayname
+			if portal.bridge.Config.Bridge.SetRoomNameToContactName {
+				contact, err := user.Client.Store.Contacts.GetContact(puppet.JID)
+				if err != nil {
+					puppet.log.Warnln("Failed to get contact info in createPrivatePortalFromInvite")
+				} else {
+					var newName string
+					if len(contact.FullName) > 0 {
+						newName = contact.FullName
+					} else {
+						// fall back to Display Name if FullName field is empty
+						newName = puppet.Displayname
+					}
+					portal.Name = newName
+				}
+			} else {
+				portal.Name = puppet.Displayname
+			}
 			portal.AvatarURL = puppet.AvatarURL
 			portal.Avatar = puppet.Avatar
 		} else {


### PR DESCRIPTION
In a `multi-user instances` multiple matrix users can `share contacts` and these contacts can differ in names. This restriction prevents us from setting `displayname_template` to `FullName` as FullName can be different depending on the matrix user's contact - as a puppet user can only have one display_name

This results in a bad UX as users will have to depend on PushName (WhatsApp nickname) or the phone number of the contact to identify the contact.

This commit introduces a feature to set the puppet's room name to the contact's name (FullName). This chat list can have the correct contact name (as imported from the user's phone)

Closes #405 