### PR TITLE
Send presence when typing changes

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -54,6 +54,7 @@ type BridgeConfig struct {
 	SyncDirectChatList    bool `yaml:"sync_direct_chat_list"`
 	DefaultBridgeReceipts bool `yaml:"default_bridge_receipts"`
 	DefaultBridgePresence bool `yaml:"default_bridge_presence"`
+	SendPresenceOnTyping  bool `yaml:"send_presence_on_typing"`
 
 	ForceActiveDeliveryReceipts bool `yaml:"force_active_delivery_receipts"`
 

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -147,6 +147,10 @@ bridge:
     # Existing users won't be affected when these are changed.
     default_bridge_receipts: true
     default_bridge_presence: true
+    # Send the presence as "available" to whatsapp when users start typing on a portal. 
+    # This works as a workaround for homeservers that do not support presence, and allows 
+    # users to see when the whatsapp user on the other side is typing during a conversation.
+    send_presence_on_typing: false
     # Should the bridge always send "active" delivery receipts (two gray ticks on WhatsApp)
     # even if the user isn't marked as online (e.g. when presence bridging isn't enabled)?
     #

--- a/portal.go
+++ b/portal.go
@@ -2815,6 +2815,12 @@ func (portal *Portal) setTyping(userIDs []id.UserID, state types.ChatPresence) {
 		if err != nil {
 			portal.log.Warnln("Error sending chat presence:", err)
 		}
+		if portal.bridge.Config.Bridge.SendPresenceOnTyping {
+			err = user.Client.SendPresence(types.PresenceAvailable)
+			if err != nil {
+				user.log.Warnln("Failed to set presence:", err)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This is a workaround to be able to get presence working for homeservers that do not support it. 
Since online presence is required to receive typing notifications from users on WA, this allows the users of the bridge to at least see if the contact is typing during a conversation. Otherwise, there is no feedback.