### PR TITLE
Send incoming call msg as notice instead of real messages

### DIFF
--- a/user.go
+++ b/user.go
@@ -473,7 +473,7 @@ func (user *User) handleCallStart(sender types.JID, id, callType string, ts time
 			Text:      text,
 			ID:        id,
 			Time:      ts,
-			Important: true,
+			Important: false,
 		},
 		source: user,
 	}


### PR DESCRIPTION
Sending "Incoming Call" as a normal message is misleading for the user. I made this change today after that happened to me, and I was wondering why the person had written that :) 