### PR TITLE
Run message history backfill after creating all the rooms

### DIFF
--- a/historysync.go
+++ b/historysync.go
@@ -90,10 +90,10 @@ func (user *User) handleHistorySync(evt *waProto.HistorySync) {
 
 	var backfillWait sync.WaitGroup
 	backfillWait.Add(1)
-	go user.backfillLoop(portalsToBackfill, backfillWait.Done)
 	for _, conv := range conversations {
 		user.handleHistorySyncConversation(conv, portalsToBackfill)
 	}
+	go user.backfillLoop(portalsToBackfill, backfillWait.Done)
 	close(portalsToBackfill)
 	backfillWait.Wait()
 	user.log.Infoln("Finished handling history sync with", description)


### PR DESCRIPTION
Possible temporary workaround for issue as described here:
https://github.com/matrix-org/synapse/issues/9424#issuecomment-1068351755