### PR TITLE
backfill: fix priority of backfills again

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -1347,10 +1347,10 @@ func (portal *Portal) CreateMatrixRoom(user *User, groupInfo *types.GroupInfo, i
 	}
 
 	if user.bridge.Config.Bridge.HistorySync.Backfill && backfill {
-		var priorityCounter int
-		user.EnqueueImmedateBackfill(portal, &priorityCounter)
-		user.EnqueueDeferredBackfills(portal, &priorityCounter)
-		user.EnqueueMediaBackfills(portal, &priorityCounter)
+		portals := []*Portal{portal}
+		user.EnqueueImmedateBackfills(portals)
+		user.EnqueueDeferredBackfills(portals)
+		user.EnqueueMediaBackfills(portals)
 		user.BackfillQueue.ReCheckQueue <- true
 	}
 	return nil

--- a/user.go
+++ b/user.go
@@ -585,10 +585,7 @@ func (user *User) HandleEvent(event interface{}) {
 			user.historySyncLoopsStarted = true
 
 			if user.bridge.Config.Bridge.HistorySync.BackfillMedia && user.bridge.Config.Bridge.HistorySync.EnqueueBackfillMediaNextStart {
-				var priorityCounter int
-				for _, portal := range user.bridge.GetAllPortalsForUser(user.MXID) {
-					user.EnqueueMediaBackfills(portal, &priorityCounter)
-				}
+				user.EnqueueMediaBackfills(user.bridge.GetAllPortalsForUser(user.MXID))
 			}
 		}
 	case *events.OfflineSyncPreview:


### PR DESCRIPTION
I think this finally has the correct logic for doing each stage for each portal before going on to the next stage.