### PR TITLE
Enforce Security by removing the Package Manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ ENV UID=1337 \
 
 RUN apk add --no-cache ffmpeg su-exec ca-certificates olm bash jq yq curl
 
+RUN apk del apk-tools alpine-keys
+
 COPY --from=builder /usr/bin/mautrix-whatsapp /usr/bin/mautrix-whatsapp
 COPY --from=builder /build/example-config.yaml /opt/mautrix-whatsapp/example-config.yaml
 COPY --from=builder /build/docker-run.sh /docker-run.sh


### PR DESCRIPTION
Hey there,

We want to suggest to remove the Package Manager after installing and compiling everything needed. This would remove the capability in case there is a security problem in the future to give nobudy more tools then needed. This would also mean that future apk related security holes would not affect this project. We did some tests with our repo (and off course live testing in our enviroment) where we added this in the Dockerfile and so far it has none negative affect to the build or running the application :D . It could also be possible to include the change into an existing RUN command to avoid creating a new layer in the image.

Here you can see our current build, to check out what we try out:
https://github.com/kgncloud/mautrix-whatsapp

Best Regards,

KN Team