### PR TITLE
backfill: add option to mark unread using account data

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -76,11 +76,12 @@ type BridgeConfig struct {
 	UserAvatarSync    bool `yaml:"user_avatar_sync"`
 	BridgeMatrixLeave bool `yaml:"bridge_matrix_leave"`
 
-	SyncWithCustomPuppets bool `yaml:"sync_with_custom_puppets"`
-	SyncDirectChatList    bool `yaml:"sync_direct_chat_list"`
-	DefaultBridgeReceipts bool `yaml:"default_bridge_receipts"`
-	DefaultBridgePresence bool `yaml:"default_bridge_presence"`
-	SendPresenceOnTyping  bool `yaml:"send_presence_on_typing"`
+	SyncWithCustomPuppets  bool `yaml:"sync_with_custom_puppets"`
+	SyncDirectChatList     bool `yaml:"sync_direct_chat_list"`
+	SyncManualMarkedUnread bool `yaml:"sync_manual_marked_unread"`
+	DefaultBridgeReceipts  bool `yaml:"default_bridge_receipts"`
+	DefaultBridgePresence  bool `yaml:"default_bridge_presence"`
+	SendPresenceOnTyping   bool `yaml:"send_presence_on_typing"`
 
 	ForceActiveDeliveryReceipts bool `yaml:"force_active_delivery_receipts"`
 

--- a/database/historysync.go
+++ b/database/historysync.go
@@ -115,20 +115,11 @@ func (hsc *HistorySyncConversation) Upsert() {
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 		ON CONFLICT (user_mxid, conversation_id)
 		DO UPDATE SET
-			portal_jid=EXCLUDED.portal_jid,
-			portal_receiver=EXCLUDED.portal_receiver,
 			last_message_timestamp=CASE
 				WHEN EXCLUDED.last_message_timestamp > history_sync_conversation.last_message_timestamp THEN EXCLUDED.last_message_timestamp
 				ELSE history_sync_conversation.last_message_timestamp
 			END,
-			archived=EXCLUDED.archived,
-			pinned=EXCLUDED.pinned,
-			mute_end_time=EXCLUDED.mute_end_time,
-			disappearing_mode=EXCLUDED.disappearing_mode,
-			end_of_history_transfer_type=EXCLUDED.end_of_history_transfer_type,
-			ephemeral_expiration=EXCLUDED.ephemeral_expiration,
-			marked_as_unread=EXCLUDED.marked_as_unread,
-			unread_count=EXCLUDED.unread_count
+			end_of_history_transfer_type=EXCLUDED.end_of_history_transfer_type
 	`,
 		hsc.UserID,
 		hsc.ConversationID,

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -201,6 +201,11 @@ bridge:
     # Note that updating the m.direct event is not atomic (except with mautrix-asmux)
     # and is therefore prone to race conditions.
     sync_direct_chat_list: false
+    # Should the bridge use MSC2867 to bridge manual "mark as unread"s from
+    # WhatsApp and set the unread status on initial backfill?
+    # This will only work on clients that support the m.marked_unread or
+    # com.famedly.marked_unread room account data.
+    sync_manual_marked_unread: true
     # When double puppeting is enabled, users can use `!wa toggle` to change whether
     # presence and read receipts are bridged. These settings set the default values.
     # Existing users won't be affected when these are changed.

--- a/historysync.go
+++ b/historysync.go
@@ -237,6 +237,8 @@ func (user *User) backfillInChunks(req *database.Backfill, conv *database.Histor
 
 	if !conv.MarkedAsUnread && conv.UnreadCount == 0 {
 		user.markSelfReadFull(portal)
+	} else if user.bridge.Config.Bridge.SyncManualMarkedUnread {
+		user.markUnread(portal, true)
 	}
 }
 


### PR DESCRIPTION
Adds an option to mark unread during backfill using the MSC2867 room account data.