### PR TITLE
Support plumbing WA groups 

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -952,7 +952,7 @@ func canDeletePortal(portal *Portal, userID id.UserID) bool {
 			continue
 		}
 		user := portal.bridge.GetUserByMXID(otherUser)
-		if user != nil && user.Session != nil {
+		if user != nil && (user.Session != nil || portal.bridge.Config.Bridge.AllowUserInvite) {
 			return false
 		}
 	}

--- a/commands.go
+++ b/commands.go
@@ -132,14 +132,14 @@ func getBridgeRoomID(ce *WrappedCommandEvent, argIndex int) (roomID id.RoomID, o
 		resp, err := ce.MainIntent().ResolveAlias(id.RoomAlias(roomArg))
 		if err != nil {
 			ce.Log.Errorln("Failed to resolve room alias %s to a room ID: %v", roomArg, err)
-			ce.Reply("Unable to find a room with the provided alias")
+			ce.Reply("Unable to find a room with the provided alias.")
 			return
 		} else {
 			roomID = resp.RoomID
 		}
 	}
 	if roomID == "" {
-		ce.Reply("Invalid room ID")
+		ce.Reply("Please provide a valid room ID.")
 		return
 	}
 

--- a/commands.go
+++ b/commands.go
@@ -250,7 +250,7 @@ func getPortalForCmd(ce *WrappedCommandEvent, argIndex int) (portal *Portal) {
 		} else if len(ce.Args) <= argIndex {
 			roomString = "that room"
 		} else {
-			roomString = ce.Args[argIndex]
+			roomString = fmt.Sprintf("[%[1]s](https://matrix.to/#/%[1]s)", ce.Args[argIndex])
 		}
 		ce.Reply("That command can only be ran for portal rooms, and %s is not a portal room.", roomString)
 	}

--- a/commands.go
+++ b/commands.go
@@ -143,7 +143,7 @@ func getBridgeRoomID(ce *WrappedCommandEvent, argIndex int, hereByDefault bool) 
 		if hereByDefault {
 			roomID = ce.RoomID
 		}
-	} else if roomArg := ce.Args[argIndex]; roomArg == "--here" {
+	} else if roomArg := ce.Args[argIndex]; strings.ToLower(roomArg) == roomArgHere {
 		roomID = ce.RoomID
 	} else {
 		var isAlias bool
@@ -1279,7 +1279,7 @@ func fnBridge(ce *WrappedCommandEvent) {
 	}
 
 	if len(ce.Args) == 1 {
-		ce.Args = append(ce.Args, "--here")
+		ce.Args = append(ce.Args, roomArgHere)
 	}
 	fnOpen(ce)
 }

--- a/commands.go
+++ b/commands.go
@@ -907,22 +907,16 @@ func fnPing(ce *WrappedCommandEvent) {
 }
 
 func checkUnbridgePermission(portal *Portal, ce *WrappedCommandEvent) bool {
-	thatThisSuffix := getThatThisSuffix(portal.MXID, ce.RoomID)
-	errMsg := fmt.Sprintf("You do not have the permissions to unbridge th%s portal.", thatThisSuffix)
-
 	if portal.IsPrivateChat() {
-		if portal.Key.Receiver != ce.User.JID {
-			ce.Reply(errMsg)
-			return false
+		if portal.Key.Receiver == ce.User.JID {
+			return true
 		}
+	} else if userHasPowerLevel(ce.Portal.MXID, ce.MainIntent(), ce.User, "unbridge") {
+		return true
 	}
 
-	if !userHasPowerLevel(ce.Portal.MXID, ce.MainIntent(), ce.User, "unbridge") {
-		ce.Reply(errMsg)
-		return false
-	}
-
-	return true
+	ce.Reply("You do not have the permissions to unbridge th%s portal.", getThatThisSuffix(portal.MXID, ce.RoomID))
+	return false
 }
 
 var cmdUnbridge = &commands.FullHandler{

--- a/commands.go
+++ b/commands.go
@@ -265,7 +265,7 @@ func userHasPowerLevel(roomID id.RoomID, intent *appservice.IntentAPI, sender *U
 	if err != nil || levels == nil {
 		return false
 	}
-	eventType := event.Type{Type: "fi.mau.whatsapp" + stateEventName, Class: event.StateEventType}
+	eventType := event.Type{Type: "fi.mau.whatsapp." + stateEventName, Class: event.StateEventType}
 	return levels.GetUserLevel(sender.MXID) >= levels.GetEventLevel(eventType)
 }
 

--- a/commands.go
+++ b/commands.go
@@ -75,6 +75,7 @@ func (br *WABridge) RegisterCommands() {
 		cmdBackfill,
 		cmdList,
 		cmdSearch,
+		cmdBridge,
 		cmdOpen,
 		cmdPM,
 		cmdSync,
@@ -114,8 +115,9 @@ var (
 	HelpSectionInvites              = commands.HelpSection{Name: "Group invites", Order: 25}
 	HelpSectionMiscellaneous        = commands.HelpSection{Name: "Miscellaneous", Order: 30}
 
-	roomArgHelpMd = " [<_Matrix room ID_> | --here]"
-	roomArgHelp   = " [<Matrix room ID> | --here]"
+	roomArgName   = "Matrix room ID or alias"
+	roomArgHelpMd = " [<_" + roomArgName + "_> | --here]"
+	roomArgHelp   = " [<" + roomArgName + "> | --here]"
 )
 
 func getBridgeRoomID(ce *WrappedCommandEvent, argIndex int) (roomID id.RoomID, ok bool) {
@@ -1102,6 +1104,29 @@ func fnSearch(ce *WrappedCommandEvent) {
 	}
 
 	ce.Reply(strings.Join(result, "\n\n"))
+}
+
+var cmdBridge = &commands.FullHandler{
+	Func: wrapCommand(fnBridge),
+	Name: "bridge",
+	Help: commands.HelpMeta{
+		Section:     HelpSectionCreatingPortals,
+		Description: "Bridge a WhatsApp group chat to the current Matrix room, or to a specified room.",
+		Args:        "<_group JID_> [<_" + roomArgName + "_>]",
+	},
+	RequiresLogin: true,
+}
+
+func fnBridge(ce *WrappedCommandEvent) {
+	if len(ce.Args) == 0 {
+		ce.Reply("**Usage:** `bridge <group JID> [<_" + roomArgName + "_>]`")
+		return
+	}
+
+	if len(ce.Args) == 1 {
+		ce.Args = append(ce.Args, "--here")
+	}
+	fnOpen(ce)
 }
 
 var cmdOpen = &commands.FullHandler{

--- a/commands.go
+++ b/commands.go
@@ -658,6 +658,27 @@ func fnCreate(ce *WrappedCommandEvent) {
 		return
 	}
 
+	ce.User.CommandState = map[string]interface{}{
+		"next":         &StateHandler{confirmCreate, "Group creation"},
+		"bridgeToMXID": bridgeRoomID,
+	}
+	ce.Reply("To confirm creating a WhatsApp group for th%s room, "+
+		"use `$cmdprefix  continue`. To cancel, use `$cmdprefix  cancel`.",
+		getThatThisSuffix(bridgeRoomID, ce.RoomID),
+	)
+}
+
+func confirmCreate(ce *WrappedCommandEvent) {
+	status := ce.User.GetCommandState()
+	bridgeRoomID := status["bridgeToMXID"].(id.RoomID)
+
+	if ce.Args[0] != "continue" {
+		ce.Reply("Please use `$cmdprefix  continue` to confirm the joining or " +
+			"`$cmdprefix  cancel` to cancel.")
+		return
+	}
+	ce.User.CommandState = nil
+
 	portal, _, errMsg := createGroup(ce.User, bridgeRoomID, ce.Log, ce.Reply)
 	if errMsg != "" {
 		ce.Reply(errMsg)

--- a/commands.go
+++ b/commands.go
@@ -1491,9 +1491,6 @@ func confirmBridge(ce *WrappedCommandEvent) {
 	status := ce.User.GetCommandState()
 	roomID := status["bridgeToMXID"].(id.RoomID)
 	portal := ce.User.GetPortalByJID(status["jid"].(types.JID))
-	if portal == nil {
-		panic("could not retrieve portal that was expected to exist")
-	}
 
 	_, mxidInStatus := status["mxid"]
 	if mxidInStatus {

--- a/commands.go
+++ b/commands.go
@@ -191,21 +191,20 @@ func getInitialState(intent *appservice.IntentAPI, roomID id.RoomID) (
 
 func warnMissingPower(levels *event.PowerLevelsEventContent, ce *WrappedCommandEvent) {
 	if levels.GetUserLevel(ce.Bot.UserID) < levels.Redact() {
-		ce.Reply(
-			"Warning: The bot does not have privileges to redact messages on Matrix. " +
-			"Message deletions from WhatsApp will not be bridged unless you give " +
+		ce.Reply("Warning: The bot does not have privileges to redact messages on Matrix. "+
+			"Message deletions from WhatsApp will not be bridged unless you give "+
 			"redaction permissions to [%[1]s](https://matrix.to/#/%[1]s)",
 			ce.Bot.UserID,
 		)
 	}
 	/* TODO Check other permissions too:
-		Important:
-		- invite/kick
-		Optional:
-		- m.bridge/uk.half-shot.bridge
-		- set room name/topic/avatar
-		- change power levels
-		- top PL for bot to control all users, including initial inviter
+	Important:
+	- invite/kick
+	Optional:
+	- m.bridge/uk.half-shot.bridge
+	- set room name/topic/avatar
+	- change power levels
+	- top PL for bot to control all users, including initial inviter
 	*/
 }
 
@@ -1153,24 +1152,22 @@ func fnOpen(ce *WrappedCommandEvent) {
 			// TODO Move to a function
 			hasPortalMessage := "That WhatsApp group already has a portal at [%[1]s](https://matrix.to/#/%[1]s). "
 			if !userHasPowerLevel(portal.MXID, ce.MainIntent(), ce.User, "unbridge") {
-				ce.Reply(
-					hasPortalMessage +
+				ce.Reply(hasPortalMessage+
 					"Additionally, you do not have the permissions to unbridge that room.",
 					portal.MXID,
 				)
 			} else {
 				ce.User.CommandState = map[string]interface{}{
-					"next": &StateHandler{confirmBridge, "Room bridging"},
-					"mxid": portal.MXID,
+					"next":         &StateHandler{confirmBridge, "Room bridging"},
+					"mxid":         portal.MXID,
 					"bridgeToMXID": bridgeRoomID,
-					"jid": info.JID,
+					"jid":          info.JID,
 				}
-				ce.Reply(
-					hasPortalMessage +
-					"However, you have the permissions to unbridge that room.\n\n" +
-					"To delete that portal completely and continue bridging, use " +
-					"`$cmdprefix  delete-and-continue`. To unbridge the portal " +
-					"without kicking Matrix users, use `$cmdprefix  unbridge-and-" +
+				ce.Reply(hasPortalMessage+
+					"However, you have the permissions to unbridge that room.\n\n"+
+					"To delete that portal completely and continue bridging, use "+
+					"`$cmdprefix  delete-and-continue`. To unbridge the portal "+
+					"without kicking Matrix users, use `$cmdprefix  unbridge-and-"+
 					"continue`. To cancel, use `$cmdprefix  cancel`.",
 					portal.MXID,
 				)
@@ -1187,12 +1184,11 @@ func fnOpen(ce *WrappedCommandEvent) {
 		} else {
 			// TODO Move to a function
 			ce.User.CommandState = map[string]interface{}{
-				"next": &StateHandler{confirmBridge, "Room bridging"},
+				"next":         &StateHandler{confirmBridge, "Room bridging"},
 				"bridgeToMXID": bridgeRoomID,
-				"jid": info.JID,
+				"jid":          info.JID,
 			}
-			ce.Reply(
-				"That WhatsApp group has no existing portal. To confirm bridging the " +
+			ce.Reply("That WhatsApp group has no existing portal. To confirm bridging the " +
 				"group, use `$cmdprefix  continue`. To cancel, use `$cmdprefix  cancel`.",
 			)
 		}
@@ -1201,8 +1197,7 @@ func fnOpen(ce *WrappedCommandEvent) {
 
 func cleanupOldPortalWhileBridging(ce *WrappedCommandEvent, portal *Portal) (bool, func()) {
 	if len(portal.MXID) == 0 {
-		ce.Reply(
-			"The portal seems to have lost its Matrix room between you" +
+		ce.Reply("The portal seems to have lost its Matrix room between you" +
 			"calling `$cmdprefix  bridge` and this command.\n\n" +
 			"Continuing without touching the previous Matrix room...",
 		)
@@ -1210,16 +1205,15 @@ func cleanupOldPortalWhileBridging(ce *WrappedCommandEvent, portal *Portal) (boo
 	}
 	switch ce.Args[0] {
 	case "delete-and-continue":
-		return true, func () {
+		return true, func() {
 			portal.Cleanup("Portal deleted (moving to another room)", false)
 		}
 	case "unbridge-and-continue":
-		return true, func () {
+		return true, func() {
 			portal.Cleanup("Room unbridged (portal moving to another room)", true)
 		}
 	default:
-		ce.Reply(
-			"The chat you were trying to bridge already has a Matrix portal room.\n\n" +
+		ce.Reply("The chat you were trying to bridge already has a Matrix portal room.\n\n" +
 			"Please use `$cmdprefix  delete-and-continue` or `$cmdprefix  unbridge-and-" +
 			"continue` to either delete or unbridge the existing room (respectively) and " +
 			"continue with the bridging.\n\n" +
@@ -1233,7 +1227,7 @@ func confirmBridge(ce *WrappedCommandEvent) {
 	defer func() {
 		if err := recover(); err != nil {
 			ce.User.CommandState = nil
-			ce.Reply("Fatal error: %v. This shouldn't happen unless you're messing with the command handler code.",	err)
+			ce.Reply("Fatal error: %v. This shouldn't happen unless you're messing with the command handler code.", err)
 		}
 	}()
 
@@ -1255,15 +1249,13 @@ func confirmBridge(ce *WrappedCommandEvent) {
 		}
 	} else if len(portal.MXID) > 0 {
 		ce.User.CommandState = nil
-		ce.Reply(
-			"The portal seems to have created a Matrix room between you " +
+		ce.Reply("The portal seems to have created a Matrix room between you " +
 			"calling `$cmdprefix  bridge` and this command.\n\n" +
 			"Please start over by calling the bridge command again.",
 		)
 		return
 	} else if ce.Args[0] != "continue" {
-		ce.Reply(
-			"Please use `$cmdprefix  continue` to confirm the bridging or " +
+		ce.Reply("Please use `$cmdprefix  continue` to confirm the bridging or " +
 			"`$cmdprefix  cancel` to cancel.",
 		)
 		return

--- a/commands.go
+++ b/commands.go
@@ -1278,6 +1278,7 @@ func lockedConfirmBridge(ce *WrappedCommandEvent, portal *Portal, roomID id.Room
 	info, err := user.Client.GetGroupInfo(portal.Key.JID)
 	if err != nil {
 		ce.Reply("Failed to get group info: %v", err)
+		return
 	}
 
 	portal.MXID = roomID

--- a/commands.go
+++ b/commands.go
@@ -142,6 +142,12 @@ func getBridgeRoomID(ce *WrappedCommandEvent, argIndex int) (roomID id.RoomID, o
 			}
 			return
 		}
+		err = ce.Bot.EnsureJoined(roomID)
+		if err != nil {
+			ce.Log.Errorln("Failed to join %s: %v", roomArg, err)
+			ce.Reply("Failed to join target room %s. Ensure that the room exists and that the bridge bot can join it.", roomArg)
+			return
+		}
 	}
 
 	var thatThisSuffix string

--- a/commands.go
+++ b/commands.go
@@ -555,7 +555,7 @@ func fnCreate(ce *WrappedCommandEvent) {
 		return
 	}
 
-	portal, _, errMsg := createGroup(ce.User, bridgeRoomID, &ce.Log, ce.Reply)
+	portal, _, errMsg := createGroup(ce.User, bridgeRoomID, ce.Log, ce.Reply)
 	if errMsg != "" {
 		ce.Reply(errMsg)
 	} else {
@@ -568,7 +568,7 @@ func fnCreate(ce *WrappedCommandEvent) {
 // If replier is set, it will be used to post user-visible messages about the progres of the group creation.
 //
 // On failure, returns an error message string (instead of an error object from a function call).
-func createGroup(user *User, roomID id.RoomID, log *log.Logger, replier func(string, ...interface{})) (
+func createGroup(user *User, roomID id.RoomID, log log.Logger, replier func(string, ...interface{})) (
 	newPortal *Portal,
 	info *types.GroupInfo,
 	errMsg string,
@@ -584,7 +584,7 @@ func createGroup(user *User, roomID id.RoomID, log *log.Logger, replier func(str
 	var roomNameEvent event.RoomNameEventContent
 	err = bridge.Bot.StateEvent(roomID, event.StateRoomName, "", &roomNameEvent)
 	if err != nil && !errors.Is(err, mautrix.MNotFound) {
-		(*log).Errorln("Failed to get room name to create group:", err)
+		log.Errorln("Failed to get room name to create group:", err)
 		errMsg = "Failed to get room name"
 		return
 	} else if len(roomNameEvent.Name) == 0 {
@@ -617,7 +617,7 @@ func createGroup(user *User, roomID id.RoomID, log *log.Logger, replier func(str
 		}
 	}
 
-	(*log).Infofln("Creating group for %s with name %s and participants %+v", roomID, roomNameEvent.Name, participants)
+	log.Infofln("Creating group for %s with name %s and participants %+v", roomID, roomNameEvent.Name, participants)
 	user.groupCreateLock.Lock()
 	defer user.groupCreateLock.Unlock()
 	resp, err := user.Client.CreateGroup(roomNameEvent.Name, participants)

--- a/commands.go
+++ b/commands.go
@@ -513,6 +513,8 @@ func fnCreate(ce *WrappedCommandEvent) {
 	}
 
 	ce.Log.Infofln("Creating group for %s with name %s and participants %+v", ce.RoomID, roomNameEvent.Name, participants)
+	ce.User.groupCreateLock.Lock()
+	defer ce.User.groupCreateLock.Unlock()
 	resp, err := ce.User.Client.CreateGroup(roomNameEvent.Name, participants)
 	if err != nil {
 		ce.Reply("Failed to create group: %v", err)
@@ -524,6 +526,7 @@ func fnCreate(ce *WrappedCommandEvent) {
 	if len(portal.MXID) != 0 {
 		portal.log.Warnln("Detected race condition in room creation")
 		// TODO race condition, clean up the old room
+		// TODO confirm whether this is fixed by the lock on group creation
 	}
 	portal.MXID = ce.RoomID
 	portal.Name = roomNameEvent.Name

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	_ "embed"
+	"errors"
 	"net/http"
 	"os"
 	"strconv"
@@ -251,6 +252,24 @@ func (br *WABridge) GetConfigPtr() interface{} {
 	}
 	br.Config.BaseConfig.Bridge = &br.Config.Bridge
 	return br.Config
+}
+
+func (br *WABridge) ResolveRoomArg(roomArg string) (roomID id.RoomID, isAlias bool, err error) {
+	// TODO Use stricter check for correct room ID/alias grammar
+	if strings.HasPrefix(roomArg, "!") {
+		roomID = id.RoomID(roomArg)
+	} else if strings.HasPrefix(roomArg, "#") {
+		isAlias = true
+		resp, resolveErr := br.AS.BotIntent().ResolveAlias(id.RoomAlias(roomArg))
+		if resolveErr != nil {
+			err = resolveErr
+		} else {
+			roomID = resp.RoomID
+		}
+	} else {
+		err = errors.New("not a valid room ID or alias")
+	}
+	return
 }
 
 func main() {

--- a/portal.go
+++ b/portal.go
@@ -3345,11 +3345,11 @@ func (portal *Portal) CleanupIfEmpty() {
 	if len(users) == 0 {
 		portal.log.Infoln("Room seems to be empty, cleaning up...")
 		portal.Delete()
-		portal.Cleanup(false)
+		portal.Cleanup("", false)
 	}
 }
 
-func (portal *Portal) Cleanup(puppetsOnly bool) {
+func (portal *Portal) Cleanup(message string, puppetsOnly bool) {
 	if len(portal.MXID) == 0 {
 		return
 	}
@@ -3366,6 +3366,9 @@ func (portal *Portal) Cleanup(puppetsOnly bool) {
 		portal.log.Errorln("Failed to get portal members for cleanup:", err)
 		return
 	}
+	if message == "" {
+		message = "Deleting portal"
+	}
 	for member := range members.Joined {
 		if member == intent.UserID {
 			continue
@@ -3377,7 +3380,7 @@ func (portal *Portal) Cleanup(puppetsOnly bool) {
 				portal.log.Errorln("Error leaving as puppet while cleaning up portal:", err)
 			}
 		} else if !puppetsOnly {
-			_, err = intent.KickUser(portal.MXID, &mautrix.ReqKickUser{UserID: member, Reason: "Deleting portal"})
+			_, err = intent.KickUser(portal.MXID, &mautrix.ReqKickUser{UserID: member, Reason: message})
 			if err != nil {
 				portal.log.Errorln("Error kicking user while cleaning up portal:", err)
 			}
@@ -3394,7 +3397,7 @@ func (portal *Portal) HandleMatrixLeave(brSender bridge.User) {
 	if portal.IsPrivateChat() {
 		portal.log.Debugln("User left private chat portal, cleaning up and deleting...")
 		portal.Delete()
-		portal.Cleanup(false)
+		portal.Cleanup("", false)
 		return
 	} else if portal.bridge.Config.Bridge.BridgeMatrixLeave {
 		err := sender.Client.LeaveGroup(portal.Key.JID)

--- a/portal.go
+++ b/portal.go
@@ -1093,6 +1093,23 @@ func (portal *Portal) UpdateMatrixRoom(user *User, groupInfo *types.GroupInfo) b
 	return true
 }
 
+func (portal *Portal) BridgeMatrixRoom(roomID id.RoomID, user *User, info *types.GroupInfo) (levels *event.PowerLevelsEventContent) {
+	portal.MXID = roomID
+	portal.bridge.portalsLock.Lock()
+	portal.bridge.portalsByMXID[portal.MXID] = portal
+	portal.bridge.portalsLock.Unlock()
+	portal.Name, portal.Topic, levels, portal.Encrypted = getInitialState(
+		portal.bridge.AS.BotIntent(), roomID,
+	)
+	portal.Avatar = ""
+	portal.Update(nil)
+	portal.UpdateBridgeInfo()
+
+	// TODO Let UpdateMatrixRoom also update power levels
+	go portal.UpdateMatrixRoom(user, info)
+	return
+}
+
 func (portal *Portal) GetBasePowerLevels() *event.PowerLevelsEventContent {
 	anyone := 0
 	nope := 99

--- a/portal.go
+++ b/portal.go
@@ -844,6 +844,13 @@ func (portal *Portal) kickExtraUsers(participantMap map[types.JID]bool) {
 				})
 				if err != nil {
 					portal.log.Warnfln("Failed to kick user %s who had left: %v", member, err)
+					puppet := portal.bridge.GetPuppetByMXID(member)
+					if puppet != nil {
+						_, err = puppet.DefaultIntent().LeaveRoom(portal.MXID)
+						if err != nil {
+							portal.log.Errorln("Error leaving as puppet for user %s who had left: %v:", member, err)
+						}
+					}
 				}
 			}
 		}

--- a/provisioning.go
+++ b/provisioning.go
@@ -483,6 +483,11 @@ func (prov *ProvisioningAPI) BridgeGroup(w http.ResponseWriter, r *http.Request)
 				ErrCode: "invalid room id",
 			})
 		}
+	} else if err := prov.bridge.Bot.EnsureJoined(roomID); err != nil {
+		jsonResponse(w, http.StatusBadRequest, Error{
+			Error:   "Bridge bot is not in target room and cannot join it",
+			ErrCode: "room unknown",
+		})
 	} else if prov.bridge.GetPortalByMXID(roomID) != nil {
 		jsonResponse(w, http.StatusConflict, Error{
 			Error:   "Room is already bridged to a WhatsApp group.",

--- a/provisioning.go
+++ b/provisioning.go
@@ -543,6 +543,13 @@ func (prov *ProvisioningAPI) BridgeGroup(w http.ResponseWriter, r *http.Request)
 			})
 			return
 		} else if len(portal.MXID) > 0 {
+			if !userHasPowerLevel(portal.MXID, prov.bridge.AS.BotIntent(), user, "unbridge") {
+				jsonResponse(w, http.StatusForbidden, Error{
+					Error:   "User does not have the permissions to unbridge that room",
+					ErrCode: "not enough permissions",
+				})
+				return
+			}
 			switch strings.ToLower(r.URL.Query().Get("force")) {
 			case "delete":
 				portal.Cleanup("Portal deleted (moving to another room)", false)

--- a/provisioning.go
+++ b/provisioning.go
@@ -659,7 +659,7 @@ func (prov *ProvisioningAPI) CreateGroup(w http.ResponseWriter, r *http.Request)
 		})
 	} else if pInfo := GetMissingRequiredPerms(roomID, prov.bridge.AS.BotIntent(), prov.bridge, prov.log); pInfo != nil {
 		missingRequiredPermsResponse(w, pInfo)
-	} else if portal, info, errMsg := createGroup(user, roomID, &prov.log, nil); errMsg != "" {
+	} else if portal, info, errMsg := createGroup(user, roomID, prov.log, nil); errMsg != "" {
 		jsonResponse(w, http.StatusForbidden, Error{
 			Error:   errMsg,
 			ErrCode: "error creating group",

--- a/user.go
+++ b/user.go
@@ -68,6 +68,7 @@ type User struct {
 
 	mgmtCreateLock  sync.Mutex
 	spaceCreateLock sync.Mutex
+	groupCreateLock sync.Mutex
 	connLock        sync.Mutex
 
 	historySyncs chan *events.HistorySync
@@ -1150,6 +1151,8 @@ func (user *User) markUnread(portal *Portal, unread bool) {
 }
 
 func (user *User) handleGroupCreate(evt *events.JoinedGroup) {
+	user.groupCreateLock.Lock()
+	defer user.groupCreateLock.Unlock()
 	portal := user.GetPortalByJID(evt.JID)
 	if len(portal.MXID) == 0 {
 		err := portal.CreateMatrixRoom(user, &evt.GroupInfo, true, true)

--- a/user.go
+++ b/user.go
@@ -83,6 +83,8 @@ type User struct {
 
 	BackfillQueue *BackfillQueue
 	BridgeState   *bridge.BridgeStateQueue
+
+	CommandState map[string]interface{}
 }
 
 func (br *WABridge) getUserByMXID(userID id.UserID, onlyIfExists bool) *User {
@@ -128,7 +130,7 @@ func (user *User) GetMXID() id.UserID {
 }
 
 func (user *User) GetCommandState() map[string]interface{} {
-	return nil
+	return user.CommandState
 }
 
 func (br *WABridge) GetUserByMXIDIfExists(userID id.UserID) *User {


### PR DESCRIPTION
Fixes #202

Plumbing is available via the `open` command by specifying which room to bridge a given WA group into, instead of creating a new room.  The room can be specified by its ID, alias, or `--here` (as a shortcut to refer to the current room).

The code & UX for this is based [mautrix-telegram](https://github.com/vector-im/mautrix-telegram)'s plumbing support, though that bridge exposes plumbing via a standalone `bridge` command.

TODO:
- Add more power level checks
- Support via the provisioning API
- Add a de-plumbing/`unbridge` command (unless `delete-portal` is good enough)
- Perhaps add plumbing support to the `join` and `pm` commands