### PR TITLE
Allow DMs to the MXID of a WhatsApp puppet that doesn't yet exist

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ type WABridge struct {
 
 func (br *WABridge) Init() {
 	br.CommandProcessor = commands.NewProcessor(&br.Bridge)
+	br.AS.QueryHandler = &WAQueryHandler{br}
 	br.RegisterCommands()
 
 	// TODO this is a weird place for this

--- a/matrix.go
+++ b/matrix.go
@@ -76,6 +76,7 @@ func (br *WABridge) CreatePrivatePortal(roomID id.RoomID, brInviter bridge.User,
 }
 
 func (br *WABridge) createPrivatePortalFromInvite(roomID id.RoomID, inviter *User, puppet *Puppet, portal *Portal) {
+	puppet.SyncContact(inviter, true, false, "handling private portal from invite")
 	portal.MXID = roomID
 	portal.Topic = PrivateChatTopic
 	_, _ = portal.MainIntent().SetRoomTopic(portal.MXID, portal.Topic)

--- a/matrix.go
+++ b/matrix.go
@@ -30,6 +30,26 @@ import (
 	"maunium.net/go/mautrix-whatsapp/database"
 )
 
+type WAQueryHandler struct {
+	bridge *WABridge
+}
+
+func (qh *WAQueryHandler) QueryAlias(alias string) bool {
+	return false
+}
+
+func (qh *WAQueryHandler) QueryUser(userID id.UserID) bool {
+	puppet := qh.bridge.GetPuppetByMXID(userID)
+	if puppet == nil {
+		return false
+	} else if err := puppet.DefaultIntent().EnsureRegistered(); err != nil {
+		puppet.log.Errorln("Failed to ensure registered:", err)
+		return false
+	} else {
+		return true
+	}
+}
+
 func (br *WABridge) CreatePrivatePortal(roomID id.RoomID, brInviter bridge.User, brGhost bridge.Ghost) {
 	inviter := brInviter.(*User)
 	puppet := brGhost.(*Puppet)


### PR DESCRIPTION
Fixes #284 

This allows starting a new WhatsApp DM by inviting a Matrix user with an ID of `@whatsapp_<phoneNumber>:domain` (or whatever the puppet user template was configured as), as an alternative to using the `pm` command.

This feature was already mostly implemented; this PR just fills the holes that were preventing it from working.