### PR TITLE
Add support for webm files

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -2787,6 +2787,18 @@ func (portal *Portal) preprocessMatrixMedia(sender *User, relaybotFormatted bool
 			return nil, util.NewDualError(errMediaDecryptFailed, err)
 		}
 	}
+	if mediaType == whatsmeow.MediaVideo && content.GetInfo().MimeType == "video/webm" {
+		data, err = ffmpeg.ConvertBytes(data, ".mp4", []string{"-f", "webm"}, []string{
+			"-pix_fmt", "yuv420p", "-c:v", "libx264", "-movflags", "+faststart",
+			"-filter:v", "crop='floor(in_w/2)*2:floor(in_h/2)*2'",
+		},
+			"webm")
+		if err != nil {
+			portal.log.Errorfln("Failed to convert webm to mp4 in %s: %v", eventID, err)
+			return nil, util.NewDualError(fmt.Errorf("%w (webm to mp4)", errMediaConvertFailed), err)
+		}
+		content.Info.MimeType = "video/mp4"
+	}
 	if mediaType == whatsmeow.MediaVideo && content.GetInfo().MimeType == "image/gif" {
 		data, err = ffmpeg.ConvertBytes(data, ".mp4", []string{"-f", "gif"}, []string{
 			"-pix_fmt", "yuv420p", "-c:v", "libx264", "-movflags", "+faststart",


### PR DESCRIPTION
### Description

Adds support for converting webm files to .mp4

### Notes

The element android client appears to compress the files in a way that breaks ffmpeg. Web client works well.
Can be tested with [this image](https://hub.docker.com/layers/242320253/apmechev/mautrix-whatsapp-test/v0.5.3/images/sha256-d10f03ec6cfe3a195425aa87b7e09c11eec8a214073ddbe3c67049eb3ac57cd6?context=repo)