### PR TITLE
Handle delete chat and leave WA group chat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/prometheus/client_golang v1.12.2-0.20220613221938-ebd77f036066
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/tidwall/gjson v1.14.1
-	go.mau.fi/whatsmeow v0.0.0-20220711111122-6340068d67de
+	go.mau.fi/whatsmeow v0.0.0-20220715134127-5e6b9804193a
 	golang.org/x/image v0.0.0-20220617043117-41969df76e82
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e
 	google.golang.org/protobuf v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ go.mau.fi/libsignal v0.0.0-20220628090436-4d18b66b087e h1:ByHDg+D+dMIGuBA2n+1xOU
 go.mau.fi/libsignal v0.0.0-20220628090436-4d18b66b087e/go.mod h1:RCdzkTWSJv0AKGqurzPXJsEGIVMuQps3E/h7CMUPous=
 go.mau.fi/whatsmeow v0.0.0-20220711111122-6340068d67de h1:ZrxHSdpUGODtCtq/0A6CXisEgWtcNwK6BGG4f+WVTlM=
 go.mau.fi/whatsmeow v0.0.0-20220711111122-6340068d67de/go.mod h1:hsjqq2xLuoFew8vbsDCJcGf5EbXCRcR/yoQ+87w6m3k=
+go.mau.fi/whatsmeow v0.0.0-20220715134127-5e6b9804193a h1:Ki4Y9d+qW/ED+7gsQ26AlQxUUyZOQ9bQEiVyjTWRmCQ=
+go.mau.fi/whatsmeow v0.0.0-20220715134127-5e6b9804193a/go.mod h1:hsjqq2xLuoFew8vbsDCJcGf5EbXCRcR/yoQ+87w6m3k=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/image v0.0.0-20220617043117-41969df76e82 h1:KpZB5pUSBvrHltNEdK/tw0xlPeD13M6M6aGP32gKqiw=

--- a/portal.go
+++ b/portal.go
@@ -2182,19 +2182,20 @@ func (portal *Portal) HandleWhatsAppInvite(source *User, senderJID *types.JID, j
 	return
 }
 
-func (portal *Portal) HandleWhatsAppDeleteChat() {
-	matrixMembers, err := portal.GetMatrixUsers()
+func (portal *Portal) HandleWhatsAppDeleteChat(user *User) {
+	matrixUsers, err := portal.GetMatrixUsers()
 	if err != nil {
 		portal.log.Errorln("Failed to get Matrix users to see if DeleteChat should be handled:", err)
 		return
 	}
-	if len(matrixMembers) > 1 {
+	if len(matrixUsers) > 1 {
 		portal.log.Infoln("Portal contains more than one Matrix user, so deleteChat will not be handled.")
 		return
+	} else if (len(matrixUsers) == 1 && matrixUsers[0] == user.MXID) || len(matrixUsers) < 1 {
+		portal.log.Debugln("User deleted chat and there are no other Matrix users using it, deleting portal...")
+		portal.Delete()
+		portal.Cleanup(false)
 	}
-	portal.log.Debugln("User deleted chat and there are no other Matrix users using it, deleting portal...")
-	portal.Delete()
-	portal.Cleanup(false)
 }
 
 const failedMediaField = "fi.mau.whatsapp.failed_media"

--- a/portal.go
+++ b/portal.go
@@ -2127,6 +2127,7 @@ func (portal *Portal) removeUser(isSameUser bool, kicker *appservice.IntentAPI, 
 			_, _ = portal.MainIntent().KickUser(portal.MXID, &mautrix.ReqKickUser{UserID: target})
 		}
 	}
+	portal.CleanupIfEmpty()
 }
 
 func (portal *Portal) HandleWhatsAppKick(source *User, senderJID types.JID, jids []types.JID) {
@@ -2179,6 +2180,21 @@ func (portal *Portal) HandleWhatsAppInvite(source *User, senderJID *types.JID, j
 		}
 	}
 	return
+}
+
+func (portal *Portal) HandleWhatsAppDeleteChat() {
+	matrixMembers, err := portal.GetMatrixUsers()
+	if err != nil {
+		portal.log.Errorln("Couldn't get Matrix users to figure out if deleteChat should be handled!")
+		return
+	}
+	if len(matrixMembers) > 1 {
+		portal.log.Infoln("Portal contains more than one Matrix user, so deleteChat will not be handled.")
+		return
+	}
+	portal.log.Debugln("User deleted chat and there are no other Matrix users using it, deleting portal...")
+	portal.Delete()
+	portal.Cleanup(false)
 }
 
 const failedMediaField = "fi.mau.whatsapp.failed_media"

--- a/portal.go
+++ b/portal.go
@@ -2185,7 +2185,7 @@ func (portal *Portal) HandleWhatsAppInvite(source *User, senderJID *types.JID, j
 func (portal *Portal) HandleWhatsAppDeleteChat() {
 	matrixMembers, err := portal.GetMatrixUsers()
 	if err != nil {
-		portal.log.Errorln("Couldn't get Matrix users to figure out if deleteChat should be handled!")
+		portal.log.Errorln("Failed to get Matrix users to see if DeleteChat should be handled:", err)
 		return
 	}
 	if len(matrixMembers) > 1 {

--- a/user.go
+++ b/user.go
@@ -924,7 +924,7 @@ func (user *User) HandleEvent(event interface{}) {
 	case *events.DeleteChat:
 		portal := user.GetPortalByJID(v.JID)
 		if portal != nil {
-			portal.HandleWhatsAppDeleteChat()
+			portal.HandleWhatsAppDeleteChat(user)
 		}
 	default:
 		user.log.Debugfln("Unknown type of event in HandleEvent: %T", v)

--- a/user.go
+++ b/user.go
@@ -921,6 +921,11 @@ func (user *User) HandleEvent(event interface{}) {
 		if user.bridge.Config.Bridge.SyncManualMarkedUnread {
 			user.markUnread(user.GetPortalByJID(v.JID), !v.Action.GetRead())
 		}
+	case *events.DeleteChat:
+		portal := user.GetPortalByJID(v.JID)
+		if portal != nil {
+			portal.HandleWhatsAppDeleteChat()
+		}
 	default:
 		user.log.Debugfln("Unknown type of event in HandleEvent: %T", v)
 	}


### PR DESCRIPTION
When user leaves a WA group chat, and no other Matrix users are using its portal, delete the portal.

When user deletes a chat ("delete" button in whatsapp that's visible on left groups and 1:1 chats), and no other Matrix users are using its portal, delete the portal.