### PR TITLE
Added audio convertion from octet-stream -> ogg

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -2861,6 +2861,15 @@ func (portal *Portal) preprocessMatrixMedia(ctx context.Context, sender *User, r
 		}
 		content.Info.MimeType = "image/png"
 	}
+	if mediaType == whatsmeow.MediaAudio && content.GetInfo().MimeType == "application/octet-stream" {
+        data, err = ffmpeg.ConvertBytes(ctx, data, ".ogg", []string{}, []string{
+            "-map", "0", "-map_metadata", "0:s:0" ,"-c:a","libopus",
+        }, content.GetInfo().MimeType)
+        if err != nil {
+                return nil, util.NewDualError(fmt.Errorf("%w (octet-stream to ogg)", errMediaConvertFailed), err)
+        }
+        content.Info.MimeType = "audio/ogg"
+    }
 	uploadResp, err := sender.Client.Upload(ctx, data, mediaType)
 	if err != nil {
 		return nil, util.NewDualError(errMediaWhatsAppUploadFailed, err)


### PR DESCRIPTION
Some matrix clients (such as FluffyChat) use .m4a or other formats for voice messages. We need to convert them to .ogg before sending them, otherwise Android WhatsApp clients won't be able to play them.