### PR TITLE
Only collect counted stats every minute

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -270,7 +270,7 @@ func (mh *MetricsHandler) startUpdatingStats() {
 			mh.log.Fatalfln("Panic in metric updater: %v\n%s", err, string(debug.Stack()))
 		}
 	}()
-	ticker := time.Tick(10 * time.Second)
+	ticker := time.Tick(60 * time.Second)
 	for {
 		mh.updateStats()
 		select {


### PR DESCRIPTION
These represent a relatively heavy query load and every 10s feels
unnecessary. Perhaps this should be removed entirely if not useful
or calculated once at startup and incrementally thereafter?