### PR TITLE
backfill: add option to only sync unread state if chat is younger than threshold

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -63,6 +63,7 @@ type BridgeConfig struct {
 		DoublePuppetBackfill    bool `yaml:"double_puppet_backfill"`
 		RequestFullSync         bool `yaml:"request_full_sync"`
 		MaxInitialConversations int  `yaml:"max_initial_conversations"`
+		UnreadHoursThreshold    int  `yaml:"unread_hours_threshold"`
 
 		Immediate struct {
 			WorkerCount int `yaml:"worker_count"`

--- a/config/upgrade.go
+++ b/config/upgrade.go
@@ -52,6 +52,7 @@ func DoUpgrade(helper *up.Helper) {
 	helper.Copy(up.Str, "bridge", "history_sync", "media_requests", "request_method")
 	helper.Copy(up.Int, "bridge", "history_sync", "media_requests", "request_local_time")
 	helper.Copy(up.Int, "bridge", "history_sync", "max_initial_conversations")
+	helper.Copy(up.Int, "bridge", "history_sync", "unread_hours_threshold")
 	helper.Copy(up.Int, "bridge", "history_sync", "immediate", "worker_count")
 	helper.Copy(up.Int, "bridge", "history_sync", "immediate", "max_events")
 	helper.Copy(up.List, "bridge", "history_sync", "deferred")

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -149,6 +149,12 @@ bridge:
         # provisioning endpoint is used or when a message comes in from that
         # chat.
         max_initial_conversations: -1
+        # If this value is greater than 0, then if the conversation's last
+        # message was more than this number of hours ago, then the conversation
+        # will automatically be marked it as read.
+        # Conversations that have a last message that is less than this number
+        # of hours ago will have their unread status synced from WhatsApp.
+        unread_hours_threshold: 0
         # Settings for immediate backfills. These backfills should generally be
         # small and their main purpose is to populate each of the initial chats
         # (as configured by max_initial_conversations) with a few messages so

--- a/historysync.go
+++ b/historysync.go
@@ -292,6 +292,8 @@ func (user *User) backfillInChunks(req *database.Backfill, conv *database.Histor
 
 	if !conv.MarkedAsUnread && conv.UnreadCount == 0 {
 		user.markSelfReadFull(portal)
+	} else if user.bridge.Config.Bridge.HistorySync.UnreadHoursThreshold > 0 && conv.LastMessageTimestamp.Before(time.Now().Add(time.Duration(-user.bridge.Config.Bridge.HistorySync.UnreadHoursThreshold)*time.Hour)) {
+		user.markSelfReadFull(portal)
 	} else if user.bridge.Config.Bridge.SyncManualMarkedUnread {
 		user.markUnread(portal, true)
 	}


### PR DESCRIPTION
Signed-off-by: Sumner Evans <sumner@beeper.com>
