### PR TITLE
Fix reconnect on remote logout issues

### DIFF
--- a/bridgestate.go
+++ b/bridgestate.go
@@ -52,7 +52,7 @@ func (user *User) GetRemoteID() string {
 	if user == nil || user.JID.IsEmpty() {
 		return ""
 	}
-	return fmt.Sprintf("%s_a%d_d%d", user.JID.User, user.JID.Agent, user.JID.Device)
+	return user.JID.User
 }
 
 func (user *User) GetRemoteName() string {

--- a/provisioning.go
+++ b/provisioning.go
@@ -543,7 +543,7 @@ func jsonResponse(w http.ResponseWriter, status int, response interface{}) {
 func (prov *ProvisioningAPI) Logout(w http.ResponseWriter, r *http.Request) {
 	user := r.Context().Value("user").(*User)
 	if user.Session == nil {
-		jsonResponse(w, http.StatusNotFound, Error{
+		jsonResponse(w, http.StatusOK, Error{
 			Error:   "You're not logged in",
 			ErrCode: "not logged in",
 		})


### PR DESCRIPTION
Change bridge state remote ID to remain constant across a reconnect, and change return status of logout to 200 when already logged out