### PR TITLE
Fix build.sh to work on FreeBSD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,8 +11,7 @@ if [ -n "${CGO_EXTRA_CPPFLAGS}" ] ; then
     if [ -z "${CGO_CPPFLAGS}" ] ; then
         export CGO_CPPFLAGS="${CGO_EXTRA_CPPFLAGS}"
     else
-        CGO_CPPFLAGS_OLD="${CGO_CPPFLAGS}"
-        export CGO_CPPFLAGS="${CGO_CPPFLAGS_OLD} ${CGO_EXTRA_CPPFLAGS}"
+        export CGO_CPPFLAGS="${CGO_CPPFLAGS} ${CGO_EXTRA_CPPFLAGS}"
     fi
 fi
 
@@ -20,8 +19,7 @@ if [ -n "${CGO_EXTRA_LDFLAGS}" ] ; then
     if [ -z "${CGO_LDFLAGS}" ] ; then
         export CGO_LDFLAGS="${CGO_EXTRA_LDFLAGS}"
     else
-        CGO_LDFLAGS_OLD="${CGO_LDFLAGS}"
-        export CGO_LDFLAGS="${CGO_LDFLAGS_OLD} ${CGO_EXTRA_LDFLAGS}"
+        export CGO_LDFLAGS="${CGO_LDFLAGS} ${CGO_EXTRA_LDFLAGS}"
     fi
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,28 @@
 #!/bin/sh
+
+CGO_EXTRA_CPPFLAGS=""
+CGO_EXTRA_LDFLAGS=""
+if [ `uname` = "FreeBSD" ] ; then
+    CGO_EXTRA_CPPFLAGS="-I/usr/local/include"
+    CGO_EXTRA_LDFLAGS="-L/usr/local/lib"
+fi
+
+if [ -n "${CGO_EXTRA_CPPFLAGS}" ] ; then
+    if [ -z "${CGO_CPPFLAGS}" ] ; then
+        export CGO_CPPFLAGS="${CGO_EXTRA_CPPFLAGS}"
+    else
+        CGO_CPPFLAGS_OLD="${CGO_CPPFLAGS}"
+        export CGO_CPPFLAGS="${CGO_CPPFLAGS_OLD} ${CGO_EXTRA_CPPFLAGS}"
+    fi
+fi
+
+if [ -n "${CGO_EXTRA_LDFLAGS}" ] ; then
+    if [ -z "${CGO_LDFLAGS}" ] ; then
+        export CGO_LDFLAGS="${CGO_EXTRA_LDFLAGS}"
+    else
+        CGO_LDFLAGS_OLD="${CGO_LDFLAGS}"
+        export CGO_LDFLAGS="${CGO_LDFLAGS_OLD} ${CGO_EXTRA_LDFLAGS}"
+    fi
+fi
+
 go build -ldflags "-X main.Tag=$(git describe --exact-match --tags 2>/dev/null) -X main.Commit=$(git rev-parse HEAD) -X 'main.BuildTime=`date '+%b %_d %Y, %H:%M:%S'`'" "$@"


### PR DESCRIPTION
FreeBSD uses the default include directory `/usr/local/include` and default library directory `/usr/local/lib` for 3rd party software.
I have to always manually modify the build script when updating to the latest tag, this should avoid that hurdle.

If you want to achieve this through some other means it's fine by me. But something like this would be cool.