### PR TITLE
Add a hack for bad clients that require thumbnail

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -2963,6 +2963,14 @@ func (portal *Portal) uploadMedia(intent *appservice.IntentAPI, data []byte, con
 	if file != nil {
 		file.URL = mxc.CUString()
 		content.File = file
+		// Temporarily fix a bug with displaying images without thumbnails in element-ios https://github.com/vector-im/element-ios/issues/4004
+		if strings.HasPrefix(content.Info.MimeType, "image/") {
+			if content.Info.ThumbnailFile != nil {
+				content.Info.ThumbnailFile = file
+			} else if content.URL.ParseOrIgnore().IsEmpty() {
+				content.Info.ThumbnailURL = content.URL
+			}
+		}
 	} else {
 		content.URL = mxc.CUString()
 	}


### PR DESCRIPTION
I tried to duplicate what was done in https://github.com/mautrix/signal/commit/4aa18d3891c7cff73b35bfa1b78730266c16864f

Changes made without proper golang environment or any knowledge on the language, so additional testing is required to ensure nothing's broken.

Presumably, without this patch, no whatsapp sticker is displayed on element-ios.

This can be removed after a fix on this issue: https://github.com/vector-im/element-ios/issues/4004