### PR TITLE
Add `config.PostProcess` method

### DIFF
--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -75,12 +75,13 @@ func (c *Config) UnmarshalYAML(node *yaml.Node) error {
 	if err != nil {
 		return err
 	}
+	return c.PostProcess()
+}
 
+func (c *Config) PostProcess() error {
+	var err error
 	c.displaynameTemplate, err = template.New("displayname").Parse(c.DisplaynameTemplate)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func upgradeConfig(helper up.Helper) {


### PR DESCRIPTION
This makes it possible to create and modify the config instance in another project.