### PR TITLE
feat: :sparkles: Bridging m.notice messages  depending on configuration

### DIFF
--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	DisableViewOnce             bool          `yaml:"disable_view_once"`
 	ForceActiveDeliveryReceipts bool          `yaml:"force_active_delivery_receipts"`
 	DirectMediaAutoRequest      bool          `yaml:"direct_media_auto_request"`
+	BridgeNotices               bool		  `yaml:"bridge_notices"`
 
 	AnimatedSticker msgconv.AnimatedStickerConfig `yaml:"animated_sticker"`
 
@@ -108,6 +109,7 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.Bool, "disable_view_once")
 	helper.Copy(up.Bool, "force_active_delivery_receipts")
 	helper.Copy(up.Bool, "direct_media_auto_request")
+	helper.Copy(up.Bool, "bridge_notices")
 
 	helper.Copy(up.Str, "animated_sticker", "target")
 	helper.Copy(up.Int, "animated_sticker", "args", "width")

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -58,6 +58,9 @@ force_active_delivery_receipts: false
 # should it be automatically requested from the phone?
 direct_media_auto_request: true
 
+# Whether or not Matrix m.notice-type messages should be bridged.
+bridge_notices: true
+
 # Settings for converting animated stickers.
 animated_sticker:
     # Format to which animated stickers should be converted.

--- a/pkg/connector/handlematrix.go
+++ b/pkg/connector/handlematrix.go
@@ -66,6 +66,7 @@ func (wa *WhatsAppClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2
 
 var ErrBroadcastSendDisabled = bridgev2.WrapErrorInStatus(errors.New("sending status messages is disabled")).WithErrorAsMessage().WithIsCertain(true).WithSendNotice(true).WithErrorReason(event.MessageStatusUnsupported)
 var ErrBroadcastReactionUnsupported = bridgev2.WrapErrorInStatus(errors.New("reacting to status messages is not currently supported")).WithErrorAsMessage().WithIsCertain(true).WithSendNotice(true).WithErrorReason(event.MessageStatusUnsupported)
+var ErrMNoticeDisabled = bridgev2.WrapErrorInStatus(errors.New("bridging m.notice messages is disabled")).WithErrorAsMessage().WithIsCertain(true).WithSendNotice(false).WithErrorReason(event.MessageStatusUnsupported)
 
 func (wa *WhatsAppClient) handleConvertedMatrixMessage(ctx context.Context, msg *bridgev2.MatrixMessage, waMsg *waE2E.Message) (*bridgev2.MatrixMessageResponse, error) {
 	messageID := wa.Client.GenerateMessageID()
@@ -78,6 +79,11 @@ func (wa *WhatsAppClient) handleConvertedMatrixMessage(ctx context.Context, msg 
 	}
 	wrappedMsgID := waid.MakeMessageID(chatJID, wa.JID, messageID)
 	msg.AddPendingToIgnore(networkid.TransactionID(wrappedMsgID))
+
+	if msg.Content.MsgType == event.MsgNotice && !wa.Main.Config.BridgeNotices {
+		return nil, ErrMNoticeDisabled
+	}
+
 	resp, err := wa.Client.SendMessage(ctx, chatJID, waMsg, whatsmeow.SendRequestExtra{
 		ID: messageID,
 	})


### PR DESCRIPTION
Add config option to disable bridging m.notice messages