### PR TITLE
feat: :sparkles: Added ping endpoint to get the status of the WhatsApp account

### DIFF
--- a/cmd/mautrix-whatsapp/main.go
+++ b/cmd/mautrix-whatsapp/main.go
@@ -48,6 +48,7 @@ func main() {
 			m.Matrix.Provisioning.Router.HandleFunc("/v1/contacts", legacyProvContacts).Methods(http.MethodPost)
 			m.Matrix.Provisioning.Router.HandleFunc("/v1/resolve_identifier/{number}", legacyProvResolveIdentifier).Methods(http.MethodGet)
 			m.Matrix.Provisioning.Router.HandleFunc("/v1/pm/{number}", legacyProvResolveIdentifier).Methods(http.MethodPost)
+			m.Matrix.Provisioning.Router.HandleFunc("/v1/ping", legacyProvPing).Methods(http.MethodGet)
 			m.Matrix.Provisioning.GetAuthFromRequest = legacyProvAuth
 		}
 	}


### PR DESCRIPTION
The new endpoint `_matrix/provision/v1/ping?user_id=@user1:domain.com` returns the status of the WhatsApp account with the next structure:

```JSON
{
    "whatsapp": {
        "has_session": true,
        "management_room": "!roomfoo:domain.com",
        "conn": {
             "is_connected": true,
             "is_logged_in": true,
         },
        "jid":  "573001111111:12@s.whatsapp.net",
       "phone": "+573001111111",
       "platform": "foo",
    },
    "mxid": "@user1:domain.com",
}
```