### PR TITLE
config: add option to mark user as always online on whatsapp

### DIFF
--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	CallStartNotices            bool          `yaml:"call_start_notices"`
 	IdentityChangeNotices       bool          `yaml:"identity_change_notices"`
 	SendPresenceOnTyping        bool          `yaml:"send_presence_on_typing"`
+	SendInitialPresenceOnline   bool          `yaml:"send_initial_presence_online"`
 	EnableStatusBroadcast       bool          `yaml:"enable_status_broadcast"`
 	DisableStatusBroadcastSend  bool          `yaml:"disable_status_broadcast_send"`
 	MuteStatusBroadcast         bool          `yaml:"mute_status_broadcast"`
@@ -103,6 +104,7 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.Bool, "call_start_notices")
 	helper.Copy(up.Bool, "identity_change_notices")
 	helper.Copy(up.Bool, "send_presence_on_typing")
+	helper.Copy(up.Bool, "send_initial_presence_online")
 	helper.Copy(up.Bool, "enable_status_broadcast")
 	helper.Copy(up.Bool, "disable_status_broadcast_send")
 	helper.Copy(up.Bool, "mute_status_broadcast")

--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	CallStartNotices            bool          `yaml:"call_start_notices"`
 	IdentityChangeNotices       bool          `yaml:"identity_change_notices"`
 	SendPresenceOnTyping        bool          `yaml:"send_presence_on_typing"`
-	SendInitialPresenceOnline   bool          `yaml:"send_initial_presence_online"`
+	SendDefaultPresenceOnline   bool          `yaml:"send_default_presence_online"`
 	EnableStatusBroadcast       bool          `yaml:"enable_status_broadcast"`
 	DisableStatusBroadcastSend  bool          `yaml:"disable_status_broadcast_send"`
 	MuteStatusBroadcast         bool          `yaml:"mute_status_broadcast"`
@@ -104,7 +104,7 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.Bool, "call_start_notices")
 	helper.Copy(up.Bool, "identity_change_notices")
 	helper.Copy(up.Bool, "send_presence_on_typing")
-	helper.Copy(up.Bool, "send_initial_presence_online")
+	helper.Copy(up.Bool, "send_default_presence_online")
 	helper.Copy(up.Bool, "enable_status_broadcast")
 	helper.Copy(up.Bool, "disable_status_broadcast_send")
 	helper.Copy(up.Bool, "mute_status_broadcast")

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -26,8 +26,8 @@ identity_change_notices: false
 # Should the bridge mark you as online on WhatsApp when you send typing notifications?
 # Full presence bridging is not supported.
 send_presence_on_typing: false
-# Should the bridge send initial presence as "online" when connecting to WhatsApp?
-send_initial_presence_online: false
+# Should the bridge send default presence as "online" when connecting to WhatsApp?
+send_default_presence_online: false
 # Should WhatsApp status messages be bridged into a Matrix room?
 enable_status_broadcast: true
 # Should sending WhatsApp status messages be allowed?

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -26,6 +26,8 @@ identity_change_notices: false
 # Should the bridge mark you as online on WhatsApp when you send typing notifications?
 # Full presence bridging is not supported.
 send_presence_on_typing: false
+# Should the bridge send initial presence as "online" when connecting to WhatsApp?
+send_initial_presence_online: false
 # Should WhatsApp status messages be bridged into a Matrix room?
 enable_status_broadcast: true
 # Should sending WhatsApp status messages be allowed?

--- a/pkg/connector/handlewhatsapp.go
+++ b/pkg/connector/handlewhatsapp.go
@@ -150,7 +150,7 @@ func (wa *WhatsAppClient) handleWAEvent(rawEvt any) (success bool) {
 		// Send presence when connecting and when the pushname is changed.
 		// This makes sure that outgoing messages always have the right pushname.
 		wa.sendDefaultPresence(log, "push name update")
-		_, _, err = wa.GetStore().Contacts.PutPushName(ctx, wa.JID.ToNonAD(), evt.Action.GetName())
+		_, _, err := wa.GetStore().Contacts.PutPushName(ctx, wa.JID.ToNonAD(), evt.Action.GetName())
 		if err != nil {
 			log.Err(err).Msg("Failed to update push name in store")
 		}

--- a/pkg/connector/handlewhatsapp.go
+++ b/pkg/connector/handlewhatsapp.go
@@ -162,7 +162,11 @@ func (wa *WhatsAppClient) handleWAEvent(rawEvt any) (success bool) {
 		wa.UserLogin.BridgeState.Send(status.BridgeState{StateEvent: status.StateConnected})
 		if len(wa.GetStore().PushName) > 0 {
 			go func() {
-				err := wa.Client.SendPresence(types.PresenceUnavailable)
+				presence := types.PresenceUnavailable
+				if wa.Main.Config.SendInitialPresenceOnline {
+					presence = types.PresenceAvailable
+				}
+				err := wa.Client.SendPresence(presence)
 				if err != nil {
 					log.Warn().Err(err).Msg("Failed to send initial presence after connecting")
 				}


### PR DESCRIPTION
allows setting the initial presence as available which makes the current user online (and thus receive typing events)