### PR TITLE
handle HD_IMAGE_DUAL_UPLOAD and HD_VIDEO_DUAL_UPLOAD

### DIFF
--- a/pkg/connector/handlewhatsapp.go
+++ b/pkg/connector/handlewhatsapp.go
@@ -292,8 +292,8 @@ func (wa *WhatsAppClient) handleWAMessage(ctx context.Context, evt *events.Messa
 	}
 	messageAssoc := evt.Message.GetMessageContextInfo().GetMessageAssociation()
 	assocType := messageAssoc.GetAssociationType()
-	if (assocType == waE2E.MessageAssociation_HD_IMAGE_DUAL_UPLOAD ||
-		assocType == waE2E.MessageAssociation_HD_VIDEO_DUAL_UPLOAD) {
+	if assocType == waE2E.MessageAssociation_HD_IMAGE_DUAL_UPLOAD ||
+		assocType == waE2E.MessageAssociation_HD_VIDEO_DUAL_UPLOAD {
 		parentKey := messageAssoc.GetParentMessageKey()
 		associatedMessage := evt.Message.GetAssociatedChildMessage().GetMessage()
 		wa.UserLogin.Log.Debug().

--- a/pkg/connector/handlewhatsapp.go
+++ b/pkg/connector/handlewhatsapp.go
@@ -290,10 +290,9 @@ func (wa *WhatsAppClient) handleWAMessage(ctx context.Context, evt *events.Messa
 		wa.Client.ManualHistorySyncDownload {
 		wa.saveWAHistorySyncNotification(ctx, evt.Message.ProtocolMessage.HistorySyncNotification)
 	}
+
 	messageAssoc := evt.Message.GetMessageContextInfo().GetMessageAssociation()
-	assocType := messageAssoc.GetAssociationType()
-	if assocType == waE2E.MessageAssociation_HD_IMAGE_DUAL_UPLOAD ||
-		assocType == waE2E.MessageAssociation_HD_VIDEO_DUAL_UPLOAD {
+	if assocType := messageAssoc.GetAssociationType(); assocType == waE2E.MessageAssociation_HD_IMAGE_DUAL_UPLOAD || assocType == waE2E.MessageAssociation_HD_VIDEO_DUAL_UPLOAD {
 		parentKey := messageAssoc.GetParentMessageKey()
 		associatedMessage := evt.Message.GetAssociatedChildMessage().GetMessage()
 		wa.UserLogin.Log.Debug().


### PR DESCRIPTION
looks like whatsapp is now uploading a SD version first and replacing the message with a HD version subsequently (which currently shows up as "Unknown message type, please view it on the WhatsApp app")

have only received such messages and haven't been able to send so testing is still pending.