### PR TITLE
Fix PDF filenames showing as "untitled" when sent through bridge

### DIFF
--- a/pkg/msgconv/from-matrix.go
+++ b/pkg/msgconv/from-matrix.go
@@ -255,9 +255,14 @@ func (mc *MessageConverter) constructMediaMessage(
 			},
 		}
 	case event.MsgFile:
+		fileName := content.FileName
+		if fileName == "" {
+			fileName = content.Body
+		}
+
 		msg := &waE2E.Message{
 			DocumentMessage: &waE2E.DocumentMessage{
-				FileName: proto.String(content.FileName),
+				FileName: proto.String(fileName),
 
 				Caption:       proto.String(caption),
 				JPEGThumbnail: thumbnail,


### PR DESCRIPTION
## Problem
When sending PDF files (and other documents) through the WhatsApp bridge, the filename was being changed to "untitled" on the receiving end, even when the original file had a proper name.

## Root Cause
The issue was in the `constructMediaMessage` function in `pkg/msgconv/from-matrix.go`. When constructing document messages for WhatsApp, the code was directly using `content.FileName` without checking if it was empty:

```go
FileName: proto.String(content.FileName),
```

When `content.FileName` was empty, WhatsApp would default to showing "untitled" as the filename.

## Solution
Added a fallback mechanism to use `content.Body` when `content.FileName` is empty, matching the same logic already used in the `reuploadFileToWhatsApp` function:

```go
fileName := content.FileName
if fileName == "" {
    fileName = content.Body
}
```

## Testing
- [x] PDF files now retain their original filenames when sent through the bridge
- [x] Other document types (Word, Excel, etc.) also benefit from this fix
- [x] No regression for files that already have proper filenames
- [x] Maintains backward compatibility

## Impact
- Improves user experience by preserving original filenames
- Fixes a common issue reported by users
- Minimal code change with no breaking changes