### PR TITLE
resync: resync portals/ghosts immediately upon viewing

### DIFF
--- a/pkg/connector/commands.go
+++ b/pkg/connector/commands.go
@@ -119,9 +119,10 @@ func fnSync(ce *commands.Event) {
 			ce.Reply("Failed to get joined groups: %v", err)
 			return
 		}
+		_, capVer := wa.Main.GetBridgeInfoVersion()
 		for _, group := range groups {
 			wrapped := wa.wrapGroupInfo(ce.Ctx, group)
-			wrapped.ExtraUpdates = bridgev2.MergeExtraUpdaters(wrapped.ExtraUpdates, updatePortalLastSyncAt)
+			wrapped.ExtraUpdates = bridgev2.MergeExtraUpdaters(wrapped.ExtraUpdates, updatePortalSyncMeta(capVer))
 			wa.addExtrasToWrapped(ce.Ctx, group.JID, wrapped, nil)
 			login.QueueRemoteEvent(&simplevent.ChatResync{
 				EventMeta: simplevent.EventMeta{

--- a/pkg/waid/dbmeta.go
+++ b/pkg/waid/dbmeta.go
@@ -111,6 +111,9 @@ type PortalMetadata struct {
 	CommunityAnnouncementGroup bool                 `json:"is_cag,omitempty"`
 	AddressingMode             types.AddressingMode `json:"addressing_mode,omitempty"`
 	LIDMigrationAttempted      bool                 `json:"lid_migration_attempted,omitempty"`
+	// BridgeCapsVersion stores the last seen capabilities version for this portal,
+	// used to decide if a lazy resync-on-view is needed when the bridge version changes.
+	BridgeCapsVersion int `json:"bridge_caps_version,omitempty"`
 }
 
 type GhostMetadata struct {


### PR DESCRIPTION
- refactor all the resync delays to a single per ghost/portal resync interval
- trigger resync immediately upon opening a room
- also resync portals if bridge capabilities has changed
