### PR TITLE
fix: not forwarding ratelimited error from whatsapp

### DIFF
--- a/pkg/connector/login.go
+++ b/pkg/connector/login.go
@@ -74,6 +74,11 @@ var (
 		Err:        "Phone number must be in international format",
 		StatusCode: http.StatusBadRequest,
 	}
+	ErrRateLimitedByWhatsApp = bridgev2.RespError{
+		ErrCode:    "FI.MAU.WHATSAPP.RATE_LIMITED",
+		Err:        "Rate limited by WhatsApp",
+		StatusCode: http.StatusTooManyRequests,
+	}
 )
 
 func (wa *WhatsAppConnector) CreateLogin(_ context.Context, user *bridgev2.User, flowID string) (bridgev2.LoginProcess, error) {
@@ -196,6 +201,8 @@ func (wl *WALogin) SubmitUserInput(ctx context.Context, input map[string]string)
 			return nil, ErrPhoneNumberTooShort
 		} else if errors.Is(err, whatsmeow.ErrPhoneNumberIsNotInternational) {
 			return nil, ErrPhoneNumberIsNotInternational
+		} else if errors.Is(err, whatsmeow.ErrIQRateOverLimit) {
+			return nil, ErrRateLimitedByWhatsApp
 		}
 		return nil, err
 	}


### PR DESCRIPTION
currently the whatsapp login does not handle ratelimits received from WhatsApp leading to synapse(or the matrix) server interpreting it as a `500` and sending that back to the client(we use elementX) instead of correct status code.

sharing logs incase they are helpful
```
2025-10-17T12:36:54.476Z DBG <iq from="s.whatsapp.net" id="22.238-1" type="error"><error code="429" text="rate-overlimit"/></iq> action=login phone_code=true sublogger=Recv user_mxid=@+[REDACTED]
2025-10-17T12:36:54.476Z ERR Failed to request phone code login error="info query returned status 429: rate-overlimit" action=login phone_code=true user_mxid=@+[REDACTED]
```