### PR TITLE
Add name quality tracking to prevent display name flip-flopping

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,62 @@
+name: Build and Push Docker Image
+
+# This workflow builds the mautrix-whatsapp image with the
+# `name-quality-tracking` patch on top of the upstream base it was
+# rebased onto. Triggers on push to the name-quality-tracking branch.
+#
+# Tags pushed:
+#   :name-quality            - rolling pointer to the latest build
+#   :sha-<short>             - immutable per commit
+#   :v<upstream>-name-quality - immutable, encodes upstream version
+
+on:
+  push:
+    branches:
+      - name-quality-tracking
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need tags for closest-tag detection
+
+      - name: Compute upstream base tag
+        id: base
+        run: |
+          # Find the latest upstream v* tag that is ancestor of HEAD
+          BASE=$(git tag -l "v*" --sort=-v:refname | head -50 | while read t; do
+            if git merge-base --is-ancestor "$t" HEAD 2>/dev/null; then
+              echo "$t"; break
+            fi
+          done)
+          echo "base=${BASE:-unknown}" >> "$GITHUB_OUTPUT"
+          SHORT=$(git rev-parse --short HEAD)
+          echo "short=${SHORT}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.ci
+          push: true
+          tags: |
+            ghcr.io/jlxq0/mautrix-whatsapp:name-quality
+            ghcr.io/jlxq0/mautrix-whatsapp:sha-${{ steps.base.outputs.short }}
+            ghcr.io/jlxq0/mautrix-whatsapp:${{ steps.base.outputs.base }}-name-quality
+          labels: |
+            org.opencontainers.image.source=https://github.com/jlxq0/whatsapp
+            org.opencontainers.image.description=mautrix-whatsapp with name-quality-tracking patch
+            org.opencontainers.image.version=${{ steps.base.outputs.base }}-name-quality

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,9 +53,9 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ghcr.io/jlxq0/mautrix-whatsapp:name-quality
-            ghcr.io/jlxq0/mautrix-whatsapp:sha-${{ steps.base.outputs.short }}
-            ghcr.io/jlxq0/mautrix-whatsapp:${{ steps.base.outputs.base }}-name-quality
+            ghcr.io/jlxq0/whatsapp:name-quality
+            ghcr.io/jlxq0/whatsapp:sha-${{ steps.base.outputs.short }}
+            ghcr.io/jlxq0/whatsapp:${{ steps.base.outputs.base }}-name-quality
           labels: |
             org.opencontainers.image.source=https://github.com/jlxq0/whatsapp
             org.opencontainers.image.description=mautrix-whatsapp with name-quality-tracking patch

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile.ci
+          file: ./Dockerfile
           push: true
           tags: |
             ghcr.io/jlxq0/mautrix-whatsapp:name-quality

--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -21,6 +21,16 @@ const (
 	MediaRequestMethodLocalTime MediaRequestMethod = "local_time"
 )
 
+// NameQuality represents the quality/priority of a display name source.
+// Higher values are better quality and should not be overwritten by lower quality names.
+const (
+	NameQualityNone         int = 0 // No name available
+	NameQualityPushName     int = 1 // User's self-set push name (can change frequently)
+	NameQualityPhone        int = 2 // Phone number (stable but not human-readable)
+	NameQualityBusinessName int = 3 // WhatsApp Business account name (stable)
+	NameQualityFullName     int = 4 // Contact list name (stable and user-preferred)
+)
+
 //go:embed example-config.yaml
 var ExampleConfig string
 
@@ -192,4 +202,23 @@ func (wa *WhatsAppConnector) GetConfig() (string, any, up.Upgrader) {
 		},
 		Base: ExampleConfig,
 	}
+}
+
+// GetNameQuality determines the quality of the display name based on available data.
+// This is used to prevent overwriting high-quality names (like contact list names)
+// with lower-quality names (like push names that can change frequently).
+func GetNameQuality(contact types.ContactInfo, phone string) int {
+	if contact.FullName != "" {
+		return NameQualityFullName
+	}
+	if contact.BusinessName != "" {
+		return NameQualityBusinessName
+	}
+	if phone != "" {
+		return NameQualityPhone
+	}
+	if contact.PushName != "" {
+		return NameQualityPushName
+	}
+	return NameQualityNone
 }

--- a/pkg/connector/handlewhatsapp.go
+++ b/pkg/connector/handlewhatsapp.go
@@ -663,13 +663,13 @@ func (wa *WhatsAppClient) syncGhost(jid types.JID, reason string, pictureID *str
 	if pictureID != nil && *pictureID != "" && ghost.AvatarID == networkid.AvatarID(*pictureID) {
 		return
 	}
-	userInfo, err := wa.getUserInfo(ctx, jid, pictureID != nil)
+	userInfo, quality, err := wa.getUserInfo(ctx, jid, pictureID != nil)
 	if err != nil {
 		log.Err(err).Msg("Failed to get user info")
 	} else {
-		ghost.UpdateInfo(ctx, userInfo)
+		updateGhostWithQualityCheck(ctx, ghost, userInfo, quality)
 		log.Debug().Msg("Synced ghost info")
-		wa.syncAltGhostWithInfo(ctx, jid, userInfo)
+		wa.syncAltGhostWithInfo(ctx, jid, userInfo, quality)
 	}
 	go wa.syncRemoteProfile(ctx, ghost)
 }

--- a/pkg/connector/startchat.go
+++ b/pkg/connector/startchat.go
@@ -196,10 +196,11 @@ func (wa *WhatsAppClient) getContactList(ctx context.Context, filter string, onl
 			continue
 		}
 		ghost, _ := wa.Main.Bridge.GetGhostByID(ctx, waid.MakeUserID(jid))
+		userInfo, _ := wa.contactToUserInfo(ctx, jid, contactInfo, false)
 		resp = append(resp, &bridgev2.ResolveIdentifierResponse{
 			Ghost:    ghost,
 			UserID:   waid.MakeUserID(jid),
-			UserInfo: wa.contactToUserInfo(ctx, jid, contactInfo, false),
+			UserInfo: userInfo,
 			Chat:     &bridgev2.CreateChatResponse{PortalKey: wa.makeWAPortalKey(jid)},
 		})
 	}

--- a/pkg/waid/dbmeta.go
+++ b/pkg/waid/dbmeta.go
@@ -123,5 +123,6 @@ type PortalMetadata struct {
 }
 
 type GhostMetadata struct {
-	LastSync jsontime.Unix `json:"last_sync,omitempty"`
+	LastSync    jsontime.Unix `json:"last_sync,omitempty"`
+	NameQuality int           `json:"name_quality,omitempty"`
 }


### PR DESCRIPTION
Track the "quality" of display name sources to prevent lower-quality names from overwriting higher-quality ones. This fixes the issue where contacts constantly flip between different name formats when WhatsApp events contain different subsets of contact data.

Quality hierarchy (highest to lowest):
- FullName (contact list name) - most stable, user-preferred
- BusinessName (WhatsApp Business account name) - stable
- Phone number - stable fallback
- PushName (user's self-set name) - can change frequently

Also prevents updating to empty names entirely.

Inspired by the similar contact_list_names implementation in mautrix-signal.

Tested in my production.