### PR TITLE
client: don't set background ctx when loading login

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -80,7 +80,6 @@ func (wa *WhatsAppConnector) LoadUserLogin(ctx context.Context, login *bridgev2.
 		w.Client.AutomaticMessageRerequestFromPhone = true
 		w.Client.GetMessageForRetry = w.trackNotFoundRetry
 		w.Client.PreRetryCallback = w.trackFoundRetry
-		w.Client.BackgroundEventCtx = w.UserLogin.Log.WithContext(wa.Bridge.BackgroundCtx)
 		w.Client.SetForceActiveDeliveryReceipts(wa.Config.ForceActiveDeliveryReceipts)
 		w.Client.InitialAutoReconnect = wa.Config.InitialAutoReconnect
 	} else {


### PR DESCRIPTION
We already set it at connect time which should be sufficient. This can panic if the bridge hasn't been started and thus has no background ctx.
