### PR TITLE
Fix HTML injection in location and group invite messages, fix panic in displayname template

### DIFF
--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -156,7 +156,7 @@ func (c *Config) FormatDisplayname(jid types.JID, phone string, contact types.Co
 	if contact.RedactedPhone == "" && phone != "" {
 		contact.RedactedPhone = redactPhone(phone)
 	}
-	err := c.displaynameTemplate.Execute(&nameBuf, &DisplaynameParams{
+	params := &DisplaynameParams{
 		ContactInfo: contact,
 		Phone:       phone,
 
@@ -166,9 +166,10 @@ func (c *Config) FormatDisplayname(jid types.JID, phone string, contact types.Co
 		VName:  contact.BusinessName,
 		Name:   contact.FullName,
 		Short:  contact.FirstName,
-	})
+	}
+	err := c.displaynameTemplate.Execute(&nameBuf, params)
 	if err != nil {
-		panic(err)
+		return params.Phone
 	}
 	return nameBuf.String()
 }

--- a/pkg/msgconv/wa-location.go
+++ b/pkg/msgconv/wa-location.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"html"
 	"image"
 	"math"
 	"net/http"
@@ -51,7 +52,7 @@ func (mc *MessageConverter) convertLocationMessage(ctx context.Context, msg *waE
 		MsgType:       event.MsgLocation,
 		Body:          fmt.Sprintf("Location: %s\n%s\n%s", name, msg.GetAddress(), url),
 		Format:        event.FormatHTML,
-		FormattedBody: fmt.Sprintf("Location: <a href='%s'>%s</a><br>%s", url, name, msg.GetAddress()),
+		FormattedBody: fmt.Sprintf(`Location: <a href="%s">%s</a><br>%s`, html.EscapeString(url), html.EscapeString(name), html.EscapeString(msg.GetAddress())),
 		GeoURI:        fmt.Sprintf("geo:%.5f,%.5f", msg.GetDegreesLatitude(), msg.GetDegreesLongitude()),
 	}
 

--- a/pkg/msgconv/wa-misc.go
+++ b/pkg/msgconv/wa-misc.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"html"
 	"html/template"
 	"strings"
 	"time"
@@ -100,7 +101,7 @@ func (mc *MessageConverter) convertGroupInviteMessage(ctx context.Context, info 
 		}
 	}
 
-	htmlMessage := fmt.Sprintf(template, event.TextToHTML(msg.GetCaption()), msg.GetGroupName(), expiry, mc.Bridge.Config.CommandPrefix)
+	htmlMessage := fmt.Sprintf(template, event.TextToHTML(msg.GetCaption()), html.EscapeString(msg.GetGroupName()), expiry, mc.Bridge.Config.CommandPrefix)
 	content := &event.MessageEventContent{
 		MsgType:       event.MsgText,
 		Body:          format.HTMLToText(htmlMessage),


### PR DESCRIPTION
- Escape url, name and address with html.EscapeString in location messages
- Escape group name with html.EscapeString in group invite messages
- Replace panic with graceful fallback in FormatDisplayname on template error