### PR TITLE
config: disable groups sync

### DIFF
--- a/pkg/connector/backfill.go
+++ b/pkg/connector/backfill.go
@@ -194,6 +194,9 @@ func (wa *WhatsAppClient) handleWAHistorySync(ctx context.Context, evt *waHistor
 		} else if jid.Server == types.BroadcastServer {
 			log.Debug().Stringer("chat_jid", jid).Msg("Skipping broadcast list in history sync")
 			continue
+		} else if wa.Main.Config.IgnoreGroupChats && jid.Server == types.GroupServer {
+			log.Debug().Stringer("chat_jid", jid).Msg("Skipping group chat in history sync (disabled in config)")
+			continue
 		} else {
 			totalMessageCount += len(conv.GetMessages())
 		}
@@ -348,6 +351,10 @@ func (wa *WhatsAppClient) createPortalsFromHistorySync(ctx context.Context) {
 			continue
 		} else if conv.ChatJID == types.PSAJID || conv.ChatJID == types.LegacyPSAJID {
 			// We don't currently support new PSAs, so don't bother backfilling them either
+			wg.Done()
+			continue
+		} else if wa.Main.Config.IgnoreGroupChats && conv.ChatJID.Server == types.GroupServer {
+			// Skip group chats completely
 			wg.Done()
 			continue
 		}

--- a/pkg/connector/chatinfo.go
+++ b/pkg/connector/chatinfo.go
@@ -40,6 +40,9 @@ func (wa *WhatsAppClient) getChatInfo(ctx context.Context, portalJID types.JID, 
 			return nil, fmt.Errorf("broadcast list bridging is currently not supported")
 		}
 	case types.GroupServer:
+		if wa.Main.Config.IgnoreGroupChats {
+			return nil, fmt.Errorf("group chat bridging is disabled")
+		}
 		info, err := wa.Client.GetGroupInfo(ctx, portalJID)
 		if err != nil {
 			return nil, err

--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	ForceActiveDeliveryReceipts bool          `yaml:"force_active_delivery_receipts"`
 	DirectMediaAutoRequest      bool          `yaml:"direct_media_auto_request"`
 	InitialAutoReconnect        bool          `yaml:"initial_auto_reconnect"`
+	IgnoreGroupChats            bool          `yaml:"ignore_group_chats"`
 	UseWhatsAppRetryStore       bool          `yaml:"use_whatsapp_retry_store"`
 
 	AnimatedSticker msgconv.AnimatedStickerConfig `yaml:"animated_sticker"`
@@ -117,6 +118,7 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.Bool, "force_active_delivery_receipts")
 	helper.Copy(up.Bool, "direct_media_auto_request")
 	helper.Copy(up.Bool, "initial_auto_reconnect")
+	helper.Copy(up.Bool, "ignore_group_chats")
 	helper.Copy(up.Bool, "use_whatsapp_retry_store")
 
 	helper.Copy(up.Str, "animated_sticker", "target")

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -64,6 +64,8 @@ force_active_delivery_receipts: false
 direct_media_auto_request: true
 # Should the bridge automatically reconnect if it fails to connect on startup?
 initial_auto_reconnect: true
+# Completely ignore all group chats - only bridge 1-on-1 conversations
+ignore_group_chats: true
 # WhatsApp messages are sometimes undecryptable. Should the bridge store messages it sends in the
 # bridge database in order to accept retry receipts from other WhatsApp users for messages sent via
 # the bridge? By default, the bridge only stores messages in memory, and therefore can't accept

--- a/pkg/connector/handlewhatsapp.go
+++ b/pkg/connector/handlewhatsapp.go
@@ -319,6 +319,10 @@ func (wa *WhatsAppClient) handleWAMessage(ctx context.Context, evt *events.Messa
 	if evt.Info.Chat == types.StatusBroadcastJID && !wa.Main.Config.EnableStatusBroadcast {
 		return
 	}
+	if wa.Main.Config.IgnoreGroupChats && evt.Info.Chat.Server == types.GroupServer {
+		wa.UserLogin.Log.Debug().Msg("Ignoring group chat message (disabled in config)")
+		return
+	}
 	if evt.Info.IsFromMe &&
 		evt.Message.GetProtocolMessage().GetHistorySyncNotification() != nil &&
 		wa.Main.Bridge.Config.Backfill.Enabled &&
@@ -425,6 +429,10 @@ func (wa *WhatsAppClient) handleWAUndecryptableMessage(ctx context.Context, evt 
 func (wa *WhatsAppClient) handleWAReceipt(ctx context.Context, evt *events.Receipt) (success bool) {
 	origChat := evt.Chat
 	wa.rerouteWAMessage(ctx, "receipt", &evt.MessageSource, evt.MessageIDs)
+	if wa.Main.Config.IgnoreGroupChats && evt.Chat.Server == types.GroupServer {
+		wa.UserLogin.Log.Debug().Msg("Ignoring group chat receipt (disabled in config)")
+		return true
+	}
 	if evt.IsFromMe && evt.Sender.Device == 0 {
 		wa.phoneSeen(evt.Timestamp)
 	}
@@ -709,6 +717,10 @@ func (wa *WhatsAppClient) handleWAPictureUpdate(ctx context.Context, evt *events
 }
 
 func (wa *WhatsAppClient) handleWAGroupInfoChange(ctx context.Context, evt *events.GroupInfo) bool {
+	if wa.Main.Config.IgnoreGroupChats && evt.JID.Server == types.GroupServer {
+		wa.UserLogin.Log.Debug().Stringer("group_jid", evt.JID).Msg("Ignoring group info change (disabled in config)")
+		return true
+	}
 	eventMeta := simplevent.EventMeta{
 		Type:         bridgev2.RemoteEventChatInfoChange,
 		LogContext:   nil,
@@ -731,6 +743,10 @@ func (wa *WhatsAppClient) handleWAGroupInfoChange(ctx context.Context, evt *even
 }
 
 func (wa *WhatsAppClient) handleWAJoinedGroup(ctx context.Context, evt *events.JoinedGroup) bool {
+	if wa.Main.Config.IgnoreGroupChats {
+		wa.UserLogin.Log.Debug().Stringer("group_jid", evt.JID).Msg("Ignoring joined group event (disabled in config)")
+		return true
+	}
 	if wa.createDedup.Pop(evt.CreateKey) {
 		return true
 	}


### PR DESCRIPTION
This PR adds a config setting `ignore_group_chats` which disables group chat sync, similar to how broadcast lists are disabled.

It is useful for our product, because we only support 1:1 messaging.