### PR TITLE
fix: bridge mark-as-unread/read state between Matrix and WhatsApp

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -55,6 +55,7 @@ func (wa *WhatsAppConnector) LoadUserLogin(ctx context.Context, login *bridgev2.
 		pushNamesSynced:           exsync.NewEvent(),
 		createDedup:               exsync.NewSet[types.MessageID](),
 		appStateFullSyncAttempted: make(map[appstate.WAPatchName]time.Time),
+		recentlyMarkedUnread:      make(map[types.JID]time.Time),
 	}
 	login.Client = w
 
@@ -121,6 +122,12 @@ type WhatsAppClient struct {
 
 	appStateRecoveryLock      sync.Mutex
 	appStateFullSyncAttempted map[appstate.WAPatchName]time.Time
+
+	// recentlyMarkedUnread tracks rooms recently marked as unread via WhatsApp
+	// AppState, so that the spurious ReadReceipt that WhatsApp sends immediately
+	// after a mark-as-unread can be suppressed.
+	recentlyMarkedUnread     map[types.JID]time.Time
+	recentlyMarkedUnreadLock sync.Mutex
 }
 
 var (

--- a/pkg/connector/handlematrix.go
+++ b/pkg/connector/handlematrix.go
@@ -635,11 +635,27 @@ func (wa *WhatsAppClient) HandleMarkedUnread(ctx context.Context, msg *bridgev2.
 	if err != nil {
 		return err
 	}
-	lastTS, lastKey, err := wa.getLastMessageInfo(ctx, chatJID, msg.Portal.PortalKey)
+	// Use LID as AppState target when available, as WhatsApp may use LID-indexed
+	// AppState entries for contacts that have been migrated.
+	targetJID := chatJID
+	if chatJID.Server == types.DefaultUserServer {
+		if lid, err := wa.GetStore().LIDs.GetLIDForPN(ctx, chatJID); err == nil && !lid.IsEmpty() {
+			targetJID = lid.ToNonAD()
+		}
+	}
+	lastTS, lastKey, err := wa.getLastMessageInfo(ctx, targetJID, msg.Portal.PortalKey)
 	if err != nil {
 		return err
 	}
-	return wa.Client.SendAppState(ctx, appstate.BuildMarkChatAsRead(chatJID, msg.Content.Unread, lastTS, lastKey))
+	// Track mark-as-unread BEFORE sending to WhatsApp so the spurious ReadReceipt
+	// that WhatsApp sends in response is suppressed. Use the phone JID as key
+	// since handleWAMarkChatAsRead converts LIDs to phone JIDs.
+	if msg.Content.Unread {
+		wa.recentlyMarkedUnreadLock.Lock()
+		wa.recentlyMarkedUnread[chatJID] = time.Now()
+		wa.recentlyMarkedUnreadLock.Unlock()
+	}
+	return wa.Client.SendAppState(ctx, appstate.BuildMarkChatAsRead(targetJID, !msg.Content.Unread, lastTS, lastKey))
 }
 
 func (wa *WhatsAppClient) HandleMatrixDeleteChat(ctx context.Context, msg *bridgev2.MatrixDeleteChat) error {

--- a/pkg/connector/handlewhatsapp.go
+++ b/pkg/connector/handlewhatsapp.go
@@ -636,14 +636,41 @@ func (wa *WhatsAppClient) handleWADeleteForMe(ctx context.Context, evt *events.D
 
 func (wa *WhatsAppClient) handleWAMarkChatAsRead(ctx context.Context, evt *events.MarkChatAsRead) bool {
 	chatJID := wa.maybeConvertJIDToLID(ctx, evt.JID)
-	return wa.UserLogin.QueueRemoteEvent(&simplevent.Receipt{
+	if evt.Action.GetRead() {
+		// Suppress ReadReceipts that arrive right after a MarkUnread for the same room.
+		// WhatsApp sends both a mark-as-unread and a read-receipt AppState patch when
+		// processing a mark-as-unread request. The read-receipt is spurious and would
+		// undo the mark-as-unread on the Matrix side.
+		wa.recentlyMarkedUnreadLock.Lock()
+		markedAt, wasRecent := wa.recentlyMarkedUnread[chatJID]
+		wa.recentlyMarkedUnreadLock.Unlock()
+		if wasRecent && time.Since(markedAt) < 5*time.Second {
+			zerolog.Ctx(ctx).Debug().
+				Stringer("chat_jid", chatJID).
+				Msg("Suppressing spurious ReadReceipt after MarkUnread")
+			return true
+		}
+		return wa.UserLogin.QueueRemoteEvent(&simplevent.Receipt{
+			EventMeta: simplevent.EventMeta{
+				Type:      bridgev2.RemoteEventReadReceipt,
+				PortalKey: wa.makeWAPortalKey(chatJID),
+				Sender:    wa.makeEventSender(ctx, wa.JID),
+				Timestamp: evt.Timestamp,
+			},
+			ReadUpTo: evt.Timestamp,
+		}).Success
+	}
+	wa.recentlyMarkedUnreadLock.Lock()
+	wa.recentlyMarkedUnread[chatJID] = time.Now()
+	wa.recentlyMarkedUnreadLock.Unlock()
+	return wa.UserLogin.QueueRemoteEvent(&simplevent.MarkUnread{
 		EventMeta: simplevent.EventMeta{
-			Type:      bridgev2.RemoteEventReadReceipt,
+			Type:      bridgev2.RemoteEventMarkUnread,
 			PortalKey: wa.makeWAPortalKey(chatJID),
 			Sender:    wa.makeEventSender(ctx, wa.JID),
 			Timestamp: evt.Timestamp,
 		},
-		ReadUpTo: evt.Timestamp,
+		Unread: true,
 	}).Success
 }
 


### PR DESCRIPTION
> **Draft:** This PR is functional and manually tested but has a known quirk with some chats on WhatsApp's side (see below). Opening as draft to get feedback on the approach.

## Summary
- **WhatsApp->Matrix:** `handleWAMarkChatAsRead` now branches on `evt.Action.GetRead()` to emit either `RemoteEventReadReceipt` (read) or `RemoteEventMarkUnread` (unread). Previously it only ever sent ReadReceipt.
- **Matrix->WhatsApp:** Fix parameter inversion in `HandleMarkedUnread` where `msg.Content.Unread` was passed directly to `BuildMarkChatAsRead`'s `read` parameter (should be negated). Also convert phone JID to LID for the AppState target, as WhatsApp uses LID-indexed AppState for some contacts.
- **Spurious ReadReceipt suppression:** WhatsApp responds to a mark-as-unread AppState patch with both a MarkUnread and a ReadReceipt event. The ReadReceipt would undo the unread state. Added tracking to suppress ReadReceipts within 5 seconds of a MarkUnread for the same room.

## Manual testing results

Tested on a real bridge deployment with Synapse + double puppeting configured.

**Working (all chats):**
- WhatsApp->Matrix: marking a chat as unread on WhatsApp correctly shows the unread indicator in Element
- Opening a chat in Element correctly clears the unread on both Element and WhatsApp
- No read/unread cycling loops observed

**Working (most chats, ~10/13 tested):**
- Matrix->WhatsApp: marking a chat as unread from Element correctly shows the unread indicator on WhatsApp

**Not working for some chats (~3/13 tested):**
- For a few specific chats, the mark-as-unread from Element does not display the unread indicator on the WhatsApp phone app
- The bridge logs confirm the AppState patch is sent correctly, WhatsApp server accepts it (version increments), and a `MarkChatAsRead(read=false)` event is received back as confirmation identical to the chats where it works
- Marking the same chats as unread directly from the WhatsApp phone works fine
- No pattern found (DMs, groups, from_me/from_them last message all mixed)
- This appears to be a WhatsApp companion device protocol behavior for specific contacts that the bridge cannot control, possibly related to WhatsApp's ongoing LID migration

### Prerequisites
Requires double puppeting to be configured:
- Bridge config: `double_puppet.secrets.<server>: "as_token:<appservice_as_token>"`
- Synapse registration: non-exclusive catch-all user regex (`^@.*:server$` with `exclusive: false`)

## Test plan
- [x] Mark unread in WhatsApp -> Element shows unread indicator
- [x] Open chat in Element -> WhatsApp clears unread
- [x] Mark unread in Element -> WhatsApp shows unread (works for most chats)
- [x] No read/unread cycling loops

Fixes #891
Depends on mautrix/go#481

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>