### PR TITLE
Convert @room mention text to @all when bridging to WhatsApp

### DIFF
--- a/pkg/msgconv/from-matrix.go
+++ b/pkg/msgconv/from-matrix.go
@@ -181,6 +181,7 @@ func (mc *MessageConverter) constructMediaMessage(
 	var caption string
 	if content.FileName != "" && content.Body != content.FileName {
 		caption, contextInfo.MentionedJID = mc.parseText(ctx, content)
+		caption = replaceRoomMention(caption, content.Mentions)
 	}
 	switch content.MsgType {
 	case event.MessageType(event.EventSticker.Type):
@@ -305,6 +306,13 @@ func (mc *MessageConverter) constructMediaMessage(
 	}
 }
 
+func replaceRoomMention(text string, mentions *event.Mentions) string {
+	if mentions != nil && mentions.Room {
+		text = strings.Replace(text, "@room", "@all", 1)
+	}
+	return text
+}
+
 func (mc *MessageConverter) parseText(ctx context.Context, content *event.MessageEventContent) (text string, mentions []string) {
 	mentions = make([]string, 0)
 
@@ -330,6 +338,7 @@ func (mc *MessageConverter) constructTextMessage(
 		return mc.constructGroupInviteMessage(ctx, content, groupInvite, contextInfo)
 	}
 	text, mentions := mc.parseText(ctx, content)
+	text = replaceRoomMention(text, content.Mentions)
 	if len(mentions) > 0 {
 		contextInfo.MentionedJID = mentions
 	}
@@ -358,6 +367,7 @@ func (mc *MessageConverter) constructGroupInviteMessage(
 		return nil, fmt.Errorf("failed to parse invite meta: %w", err)
 	}
 	text, mentions := mc.parseText(ctx, content)
+	text = replaceRoomMention(text, content.Mentions)
 	if len(mentions) > 0 {
 		contextInfo.MentionedJID = mentions
 	}

--- a/pkg/msgconv/from-whatsapp.go
+++ b/pkg/msgconv/from-whatsapp.go
@@ -239,6 +239,10 @@ func (mc *MessageConverter) ToMatrix(
 	mc.addMentions(ctx, contextInfo.GetMentionedJID(), part.Content)
 	if contextInfo.GetNonJIDMentions() == 1 {
 		part.Content.Mentions.Room = true
+		part.Content.Body = strings.Replace(part.Content.Body, "@all", "@room", 1)
+		if part.Content.FormattedBody != "" {
+			part.Content.FormattedBody = strings.Replace(part.Content.FormattedBody, "@all", "@room", 1)
+		}
 	}
 
 	cm := &bridgev2.ConvertedMessage{

--- a/pkg/msgconv/matrixpoll.go
+++ b/pkg/msgconv/matrixpoll.go
@@ -74,6 +74,7 @@ func (mc *MessageConverter) PollStartToWhatsApp(
 	contextInfo := mc.generateContextInfo(ctx, replyTo, portal, nil, content.Mentions != nil && content.Mentions.Room)
 	var question string
 	question, contextInfo.MentionedJID = mc.msc1767ToWhatsApp(ctx, content.PollStart.Question, content.Mentions)
+	question = replaceRoomMention(question, content.Mentions)
 	if len(question) == 0 {
 		return nil, nil, errPollMissingQuestion
 	}


### PR DESCRIPTION
Fixes mautrix/whatsapp#907

Converts `@room` to `@all` in the message text when sending from Matrix to WhatsApp, and `@all` to `@room` in the reverse direction. The `NonJIDMentions` protocol field was already being set correctly, this adds the missing text conversion so mentions render properly on both platforms.

WhatsApp clients localize `@all` client-side (e.g. `@everyone`, `@tutti`, `@todos`), so no locale handling is needed in the
bridge.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
