### PR TITLE
Add messages hard days limit

### DIFF
--- a/pkg/connector/backfill.go
+++ b/pkg/connector/backfill.go
@@ -211,6 +211,16 @@ func (wa *WhatsAppClient) handleWAHistorySync(
 	successfullySavedTotal := 0
 	failedToSaveTotal := 0
 	totalMessageCount := 0
+	filteredByTimeCount := 0
+	// Calculate cutoff time based on hard_days_limit configuration
+	var cutoffTime time.Time
+	if wa.Main.Config.HistorySync.HardDaysLimit > 0 {
+		cutoffTime = time.Now().AddDate(0, 0, -wa.Main.Config.HistorySync.HardDaysLimit)
+		log.Info().
+			Int("hard_days_limit", wa.Main.Config.HistorySync.HardDaysLimit).
+			Time("cutoff_time", cutoffTime).
+			Msg("Hard days limit is set, messages older than specified days will be filtered out")
+	}
 	for _, conv := range evt.GetConversations() {
 		log := log.With().
 			Int("msg_count", len(conv.GetMessages())).
@@ -273,6 +283,12 @@ func (wa *WhatsAppClient) handleWAHistorySync(
 			if maxTime.IsZero() || msgEvt.Info.Timestamp.After(maxTime) {
 				maxTime = msgEvt.Info.Timestamp
 				maxTimeIndex = i
+			}
+
+			// Filter messages older than hard_days_limit if configured
+			if !cutoffTime.IsZero() && msgEvt.Info.Timestamp.Before(cutoffTime) {
+				filteredByTimeCount++
+				continue
 			}
 
 			msgType := getMessageType(msgEvt.Message)
@@ -343,12 +359,15 @@ func (wa *WhatsAppClient) handleWAHistorySync(
 			}
 		}
 	}
-	log.Info().
+	logEvent := log.Info().
 		Int("total_saved_count", successfullySavedTotal).
 		Int("total_failed_count", failedToSaveTotal).
 		Int("total_message_count", totalMessageCount).
-		Dur("duration", time.Since(start)).
-		Msg("Finished storing history sync")
+		Dur("duration", time.Since(start))
+	if filteredByTimeCount > 0 {
+		logEvent = logEvent.Int("filtered_by_time_count", filteredByTimeCount)
+	}
+	logEvent.Msg("Finished storing history sync")
 	return nil
 }
 
@@ -714,14 +733,31 @@ func (wa *WhatsAppClient) handleOnDemandHistorySync(ctx context.Context, blob *w
 				if len(conv.GetMessages()) == 0 {
 					return &bridgev2.FetchMessagesResponse{}, nil
 				}
-				messages := make([]*waWeb.WebMessageInfo, len(conv.GetMessages()))
-				for i, rawMsg := range conv.GetMessages() {
-					messages[i] = rawMsg.Message
+				messages := make([]*waWeb.WebMessageInfo, 0, len(conv.GetMessages()))
+				// Filter messages older than hard_days_limit if configured
+				var cutoffTime time.Time
+				var filteredCount int
+				if wa.Main.Config.HistorySync.HardDaysLimit > 0 {
+					cutoffTime = time.Now().AddDate(0, 0, -wa.Main.Config.HistorySync.HardDaysLimit)
 				}
-				zerolog.Ctx(ctx).Debug().
+				for _, rawMsg := range conv.GetMessages() {
+					// Check message timestamp if filtering is enabled
+					if !cutoffTime.IsZero() {
+						msgEvt, err := wa.Client.ParseWebMessage(portalJID, rawMsg.Message)
+						if err == nil && msgEvt.Info.Timestamp.Before(cutoffTime) {
+							filteredCount++
+							continue
+						}
+					}
+					messages = append(messages, rawMsg.Message)
+				}
+				logEvent := zerolog.Ctx(ctx).Debug().
 					Int("message_count", len(messages)).
-					Stringer("end_of_history_type", conv.GetEndOfHistoryTransferType()).
-					Msg("Converting messages to bridge from on-demand history sync")
+					Stringer("end_of_history_type", conv.GetEndOfHistoryTransferType())
+				if filteredCount > 0 {
+					logEvent = logEvent.Int("filtered_by_time_count", filteredCount)
+				}
+				logEvent.Msg("Converting messages to bridge from on-demand history sync")
 				resp, err := wa.convertHistorySyncMessages(ctx, portal, portalJID, messages, false)
 				if err != nil {
 					return nil, err

--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -58,6 +58,7 @@ type Config struct {
 		MaxInitialConversations int           `yaml:"max_initial_conversations"`
 		RequestFullSync         bool          `yaml:"request_full_sync"`
 		DispatchWait            time.Duration `yaml:"dispatch_wait"`
+		HardDaysLimit           int           `yaml:"hard_days_limit"`
 		FullSyncConfig          struct {
 			DaysLimit    uint32 `yaml:"days_limit"`
 			SizeLimit    uint32 `yaml:"size_mb_limit"`
@@ -129,6 +130,7 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.Int, "history_sync", "max_initial_conversations")
 	helper.Copy(up.Bool, "history_sync", "request_full_sync")
 	helper.Copy(up.Str|up.Int, "history_sync", "dispatch_wait")
+	helper.Copy(up.Int, "history_sync", "hard_days_limit")
 	helper.Copy(up.Int|up.Null, "history_sync", "full_sync_config", "days_limit")
 	helper.Copy(up.Int|up.Null, "history_sync", "full_sync_config", "size_mb_limit")
 	helper.Copy(up.Int|up.Null, "history_sync", "full_sync_config", "storage_quota_mb")

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -115,6 +115,13 @@ func (wa *WhatsAppConnector) Init(bridge *bridgev2.Bridge) {
 	)
 	wa.mediaEditCache = make(MediaEditCache)
 
+	// Log history sync configuration
+	bridge.Log.Info().
+		Int("hard_days_limit", wa.Config.HistorySync.HardDaysLimit).
+		Bool("request_full_sync", wa.Config.HistorySync.RequestFullSync).
+		Int("max_initial_conversations", wa.Config.HistorySync.MaxInitialConversations).
+		Msg("History sync configuration loaded")
+
 	whatsmeowDBLog := bridge.Log.With().Str("db_section", "whatsmeow").Logger()
 	wa.DeviceStore = sqlstore.NewWithWrappedDB(
 		bridge.DB.Child(

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -98,6 +98,10 @@ history_sync:
     # If this is too low, the backfill may happen with incomplete history
     # and backfill less messages than what is configured in the backfill section.
     dispatch_wait: 1m
+    # Hard limit on message age in days. Messages older than this will be filtered out during history sync.
+    # Set to 0 to disable filtering. This applies to all types of history sync (initial, full, on-demand).
+    # For example, setting this to 30 will only sync messages from the last 30 days.
+    hard_days_limit: 0
     # Configuration parameters that are sent to the phone along with the request full sync flag.
     # By default, (when the values are null or 0), the config isn't sent at all.
     full_sync_config:


### PR DESCRIPTION
## Summary

Current `request_full_sync` and `full_sync_config.days_limit` settings only **request** a history range from WhatsApp, but do not **enforce** a strict message age limit. The actual amount of history returned is determined by the WhatsApp server/client side, so it is currently impossible to guarantee a hard sync cutoff by time.

This PR adds a new optional configuration setting to enforce client-side filtering:

### New Configuration Option
```
history_sync:
    # Hard limit on message age in days. Messages older than this will be filtered out during history sync.
    # Set to 0 to disable filtering. This applies to all types of history sync (initial, full, on-demand).
    # For example, setting this to 30 will only sync messages from the last 30 days.
    hard_days_limit: 0
```

**Key features:**
- 🕒 **Strict time-based filtering**: Messages older than the specified number of days are filtered out during history sync
- 🔄 **Applies to all sync types**: Works with initial sync, full sync, and on-demand sync
- 📊 **Detailed logging**: Shows `filtered_by_time_count` in logs when messages are filtered
- ⚙️ **Disabled by default**: Set to `0` by default, so existing behavior remains unchanged unless explicitly enabled
- ✅ **Backwards compatible**: No breaking changes to existing configurations

## Manual testing results

Tested on a real bridge deployment with Synapse and a real WhatsApp account.

**Test configuration:**

bridge:
history_sync:
request_full_sync: true
full_sync_config:
days_limit: 30
hard_days_limit: 3

**Test procedure:**
1. Cleared the bridge database to ensure a clean state
2. Connected a new user to trigger initial history sync
3. Monitored bridge logs for filtering behavior
4. Verified synced messages in Matrix rooms

**Working (all sync types - initial, full, on-demand):**

✅ **Messages within the hard limit are synced correctly**
- Messages from the last 3 days appeared in Matrix rooms as expected
- All message types (text, images, videos, stickers, documents, etc.) synced successfully

✅ **Messages older than the hard limit are filtered out**
- Messages older than 3 days were correctly excluded from sync
- Bridge logs showed `filtered_by_time_count` with the number of filtered messages
- No old messages appeared in Matrix rooms despite `days_limit: 30` requesting broader history from WhatsApp

✅ **Disabled mode works as expected**
- Setting `hard_days_limit: 0` disabled the filtering
- All messages within the WhatsApp-provided history range were synced

✅ **Logging provides clear feedback**
- When filtering is active, logs include:
    - `hard_days_limit` configuration value
    - `cutoff_time` timestamp
    - `filtered_by_time_count` showing how many messages were filtered
- Sample log output:

  {
  "level": "info",
  "hard_days_limit": 3,
  "cutoff_time": "2026-05-09T14:50:29Z",
  "message": "Hard days limit is set, messages older than specified days will be filtered out"
  }

  {
  "level": "info",
  "total_saved_count": 1247,
  "total_message_count": 5832,
  "filtered_by_time_count": 4585,
  "message": "Finished storing history sync"
  }

**No issues observed:**
- No performance degradation during filtering
- No sync loops or duplicate messages
- Cutoff calculation and filtering logic work correctly across different timezones
- Feature is fully backwards compatible (disabled by default)

## Test plan

- [x] Set `hard_days_limit` to a specific value (e.g., 3 days) and verify only recent messages are synced
- [x] Set `hard_days_limit: 0` and verify filtering is disabled
- [x] Check bridge logs contain `hard_days_limit`, `cutoff_time`, and `filtered_by_time_count` fields
- [x] Verify messages within the limit are synced correctly (all types)
- [x] Verify messages older than the limit are excluded
- [x] Test with initial sync, full sync, and on-demand sync
- [x] Confirm no performance issues with large message volumes

---

**Checklist**

- [x] I have read and followed the contributing guidelines at https://docs.mau.fi/bridges/general/contributing.html