### PR TITLE
msgconv/from-whatsapp: convert message history notices

### DIFF
--- a/pkg/connector/mediarequest.go
+++ b/pkg/connector/mediarequest.go
@@ -70,10 +70,9 @@ func (wa *WhatsAppClient) processFailedMedia(ctx context.Context, portalKey netw
 func (wa *WhatsAppClient) mediaRequestLoop(ctx context.Context) {
 	log := wa.UserLogin.Log.With().Str("loop", "media requests").Logger()
 	ctx = log.WithContext(ctx)
-	tzName := wa.UserLogin.Metadata.(*waid.UserLoginMetadata).Timezone
-	userTz, err := time.LoadLocation(tzName)
+	userTz, err := wa.UserLogin.Metadata.(*waid.UserLoginMetadata).LoadTimezone()
 	var startIn time.Duration
-	if tzName != "" && err == nil && userTz != nil {
+	if err == nil && userTz != nil {
 		now := time.Now()
 		startAt := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, userTz)
 		startAt = startAt.Add(time.Duration(wa.Main.Config.HistorySync.MediaRequests.RequestLocalTime) * time.Minute)

--- a/pkg/connector/wamsgtype.go
+++ b/pkg/connector/wamsgtype.go
@@ -130,6 +130,8 @@ func getMessageType(waMsg *waE2E.Message) string {
 		return "secret encrypted"
 	case waMsg.PollResultSnapshotMessage != nil:
 		return "poll result snapshot"
+	case waMsg.MessageHistoryNotice != nil:
+		return "message history notice"
 	case waMsg.MessageHistoryBundle != nil:
 		return "message history bundle"
 	case waMsg.RequestPhoneNumberMessage != nil:

--- a/pkg/msgconv/from-whatsapp.go
+++ b/pkg/msgconv/from-whatsapp.go
@@ -215,6 +215,8 @@ func (mc *MessageConverter) ToMatrix(
 		part, contextInfo = mc.convertPlaceholderMessage(ctx, waMsg)
 	case waMsg.GroupInviteMessage != nil:
 		part, contextInfo = mc.convertGroupInviteMessage(ctx, info, waMsg.GroupInviteMessage)
+	case waMsg.MessageHistoryNotice != nil:
+		part, contextInfo = mc.convertMessageHistoryNotice(ctx, info, waMsg.MessageHistoryNotice)
 	case waMsg.ProtocolMessage != nil && waMsg.ProtocolMessage.GetType() == waE2E.ProtocolMessage_EPHEMERAL_SETTING:
 		part, contextInfo = mc.convertEphemeralSettingMessage(ctx, waMsg.ProtocolMessage, info.Timestamp, isBackfill)
 	case waMsg.EncCommentMessage != nil:

--- a/pkg/msgconv/wa-misc.go
+++ b/pkg/msgconv/wa-misc.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"go.mau.fi/util/exerrors"
+	"go.mau.fi/util/exfmt"
 	"go.mau.fi/util/ptr"
 	"go.mau.fi/whatsmeow/proto/waAICommonDeprecated"
 	"go.mau.fi/whatsmeow/proto/waE2E"
@@ -117,8 +118,6 @@ func (mc *MessageConverter) convertGroupInviteMessage(ctx context.Context, info 
 	}, msg.GetContextInfo()
 }
 
-const maxMessageHistoryNoticeReceivers = 5
-
 func (mc *MessageConverter) formatMessageHistoryNoticeJID(ctx context.Context, jid types.JID) string {
 	_, displayName, err := mc.getBasicUserInfo(ctx, jid)
 	if err != nil {
@@ -126,8 +125,17 @@ func (mc *MessageConverter) formatMessageHistoryNoticeJID(ctx context.Context, j
 	} else if displayName != "" {
 		return displayName
 	}
-	return jid.String()
+	switch jid.Server {
+	case types.DefaultUserServer:
+		return "+" + jid.User
+	default:
+		return "Unknown user " + jid.String()
+	}
 }
+
+const maxMessageHistoryNoticeReceivers = 5
+
+var others = exfmt.Pluralizable("other")
 
 func (mc *MessageConverter) formatMessageHistoryNoticeReceivers(ctx context.Context, receivers []string) string {
 	receiverLimit := min(len(receivers), maxMessageHistoryNoticeReceivers)
@@ -142,12 +150,8 @@ func (mc *MessageConverter) formatMessageHistoryNoticeReceivers(ctx context.Cont
 		}
 	}
 	receiverText := strings.Join(receiverNames, ", ")
-	if remainingReceivers := len(receivers) - receiverLimit; remainingReceivers > 0 {
-		otherWord := "others"
-		if remainingReceivers == 1 {
-			otherWord = "other"
-		}
-		receiverText = fmt.Sprintf("%s + %d %s", receiverText, remainingReceivers, otherWord)
+	if len(receivers) > receiverLimit {
+		receiverText = fmt.Sprintf("%s + %s", receiverText, others(len(receivers)-receiverLimit))
 	}
 	return receiverText
 }

--- a/pkg/msgconv/wa-misc.go
+++ b/pkg/msgconv/wa-misc.go
@@ -117,6 +117,95 @@ func (mc *MessageConverter) convertGroupInviteMessage(ctx context.Context, info 
 	}, msg.GetContextInfo()
 }
 
+const maxMessageHistoryNoticeReceivers = 5
+
+func (mc *MessageConverter) formatMessageHistoryNoticeJID(ctx context.Context, jid types.JID) string {
+	_, displayName, err := mc.getBasicUserInfo(ctx, jid)
+	if err != nil {
+		zerolog.Ctx(ctx).Err(err).Stringer("jid", jid).Msg("Failed to get user info for message history notice")
+		return jid.String()
+	} else if displayName == "" {
+		return jid.String()
+	}
+	return displayName
+}
+
+func (mc *MessageConverter) formatMessageHistoryNoticeReceiver(ctx context.Context, receiver string) string {
+	jid, err := types.ParseJID(receiver)
+	if err != nil {
+		zerolog.Ctx(ctx).Err(err).Str("receiver", receiver).Msg("Failed to parse message history receiver JID")
+		return receiver
+	}
+	return mc.formatMessageHistoryNoticeJID(ctx, jid)
+}
+
+func (mc *MessageConverter) messageHistoryNoticeLocation(ctx context.Context) *time.Location {
+	portal := getPortal(ctx)
+	loginID := portal.Receiver
+	if loginID == "" {
+		loginID = waid.MakeUserLoginID(getClient(ctx).Store.GetJID().ToNonAD())
+	}
+	if login := mc.Bridge.GetCachedUserLoginByID(loginID); login != nil {
+		meta, _ := login.Metadata.(*waid.UserLoginMetadata)
+		if meta != nil && meta.Timezone != "" {
+			loc, err := time.LoadLocation(meta.Timezone)
+			if err != nil {
+				zerolog.Ctx(ctx).Err(err).Str("timezone", meta.Timezone).Msg("Failed to load user timezone for message history notice")
+			} else {
+				return loc
+			}
+		}
+	}
+	return time.Local
+}
+
+func (mc *MessageConverter) convertMessageHistoryNotice(ctx context.Context, info *types.MessageInfo, msg *waE2E.MessageHistoryNotice) (*bridgev2.ConvertedMessagePart, *waE2E.ContextInfo) {
+	metadata := msg.GetMessageHistoryMetadata()
+	receivers := metadata.GetHistoryReceivers()
+	receiverLimit := len(receivers)
+	if receiverLimit > maxMessageHistoryNoticeReceivers {
+		receiverLimit = maxMessageHistoryNoticeReceivers
+	}
+	receiverNames := make([]string, 0, receiverLimit)
+	for _, receiver := range receivers[:receiverLimit] {
+		receiverNames = append(receiverNames, mc.formatMessageHistoryNoticeReceiver(ctx, receiver))
+	}
+	receiverText := strings.Join(receiverNames, ", ")
+	if remainingReceivers := len(receivers) - receiverLimit; remainingReceivers > 0 {
+		otherWord := "others"
+		if remainingReceivers == 1 {
+			otherWord = "other"
+		}
+		receiverText = fmt.Sprintf("%s + %d %s", receiverText, remainingReceivers, otherWord)
+	}
+
+	sender := mc.formatMessageHistoryNoticeJID(ctx, info.Sender)
+	body := fmt.Sprintf("%s sent message history", sender)
+	if receiverText != "" {
+		body = fmt.Sprintf("%s to %s", body, receiverText)
+	}
+	if count := metadata.GetMessageCount(); count > 0 {
+		messageWord := "messages"
+		if count == 1 {
+			messageWord = "message"
+		}
+		body = fmt.Sprintf("%s (%d %s)", body, count, messageWord)
+	}
+	if metadata != nil && metadata.OldestMessageTimestampInWindow != nil {
+		oldestTS := time.Unix(metadata.GetOldestMessageTimestampInWindow(), 0).In(mc.messageHistoryNoticeLocation(ctx))
+		body = fmt.Sprintf("%s, starting %s", body, oldestTS.Format("Jan 2, 2006 at 3:04 PM"))
+	}
+	body += "."
+
+	return &bridgev2.ConvertedMessagePart{
+		Type: event.EventMessage,
+		Content: &event.MessageEventContent{
+			MsgType: event.MsgNotice,
+			Body:    body,
+		},
+	}, msg.GetContextInfo()
+}
+
 func (mc *MessageConverter) convertEphemeralSettingMessage(ctx context.Context, msg *waE2E.ProtocolMessage, ts time.Time, isBackfill bool) (*bridgev2.ConvertedMessagePart, *waE2E.ContextInfo) {
 	portal := getPortal(ctx)
 	portalMeta := portal.Metadata.(*waid.PortalMetadata)

--- a/pkg/msgconv/wa-misc.go
+++ b/pkg/msgconv/wa-misc.go
@@ -162,10 +162,7 @@ func (mc *MessageConverter) messageHistoryNoticeLocation(ctx context.Context) *t
 func (mc *MessageConverter) convertMessageHistoryNotice(ctx context.Context, info *types.MessageInfo, msg *waE2E.MessageHistoryNotice) (*bridgev2.ConvertedMessagePart, *waE2E.ContextInfo) {
 	metadata := msg.GetMessageHistoryMetadata()
 	receivers := metadata.GetHistoryReceivers()
-	receiverLimit := len(receivers)
-	if receiverLimit > maxMessageHistoryNoticeReceivers {
-		receiverLimit = maxMessageHistoryNoticeReceivers
-	}
+	receiverLimit := min(len(receivers), maxMessageHistoryNoticeReceivers)
 	receiverNames := make([]string, 0, receiverLimit)
 	for _, receiver := range receivers[:receiverLimit] {
 		receiverNames = append(receiverNames, mc.formatMessageHistoryNoticeReceiver(ctx, receiver))

--- a/pkg/msgconv/wa-misc.go
+++ b/pkg/msgconv/wa-misc.go
@@ -123,20 +123,33 @@ func (mc *MessageConverter) formatMessageHistoryNoticeJID(ctx context.Context, j
 	_, displayName, err := mc.getBasicUserInfo(ctx, jid)
 	if err != nil {
 		zerolog.Ctx(ctx).Err(err).Stringer("jid", jid).Msg("Failed to get user info for message history notice")
-		return jid.String()
-	} else if displayName == "" {
-		return jid.String()
+	} else if displayName != "" {
+		return displayName
 	}
-	return displayName
+	return jid.String()
 }
 
-func (mc *MessageConverter) formatMessageHistoryNoticeReceiver(ctx context.Context, receiver string) string {
-	jid, err := types.ParseJID(receiver)
-	if err != nil {
-		zerolog.Ctx(ctx).Err(err).Str("receiver", receiver).Msg("Failed to parse message history receiver JID")
-		return receiver
+func (mc *MessageConverter) formatMessageHistoryNoticeReceivers(ctx context.Context, receivers []string) string {
+	receiverLimit := min(len(receivers), maxMessageHistoryNoticeReceivers)
+	receiverNames := make([]string, 0, receiverLimit)
+	for _, receiver := range receivers[:receiverLimit] {
+		jid, err := types.ParseJID(receiver)
+		if err != nil {
+			zerolog.Ctx(ctx).Err(err).Str("receiver", receiver).Msg("Failed to parse message history receiver JID")
+			receiverNames = append(receiverNames, receiver)
+		} else {
+			receiverNames = append(receiverNames, mc.formatMessageHistoryNoticeJID(ctx, jid))
+		}
 	}
-	return mc.formatMessageHistoryNoticeJID(ctx, jid)
+	receiverText := strings.Join(receiverNames, ", ")
+	if remainingReceivers := len(receivers) - receiverLimit; remainingReceivers > 0 {
+		otherWord := "others"
+		if remainingReceivers == 1 {
+			otherWord = "other"
+		}
+		receiverText = fmt.Sprintf("%s + %d %s", receiverText, remainingReceivers, otherWord)
+	}
+	return receiverText
 }
 
 func (mc *MessageConverter) messageHistoryNoticeLocation(ctx context.Context) *time.Location {
@@ -147,13 +160,11 @@ func (mc *MessageConverter) messageHistoryNoticeLocation(ctx context.Context) *t
 	}
 	if login := mc.Bridge.GetCachedUserLoginByID(loginID); login != nil {
 		meta, _ := login.Metadata.(*waid.UserLoginMetadata)
-		if meta != nil && meta.Timezone != "" {
-			loc, err := time.LoadLocation(meta.Timezone)
-			if err != nil {
-				zerolog.Ctx(ctx).Err(err).Str("timezone", meta.Timezone).Msg("Failed to load user timezone for message history notice")
-			} else {
-				return loc
-			}
+		loc, err := meta.LoadTimezone()
+		if err != nil {
+			zerolog.Ctx(ctx).Err(err).Str("timezone", meta.Timezone).Msg("Failed to load user timezone for message history notice")
+		} else if loc != nil {
+			return loc
 		}
 	}
 	return time.Local
@@ -161,24 +172,10 @@ func (mc *MessageConverter) messageHistoryNoticeLocation(ctx context.Context) *t
 
 func (mc *MessageConverter) convertMessageHistoryNotice(ctx context.Context, info *types.MessageInfo, msg *waE2E.MessageHistoryNotice) (*bridgev2.ConvertedMessagePart, *waE2E.ContextInfo) {
 	metadata := msg.GetMessageHistoryMetadata()
-	receivers := metadata.GetHistoryReceivers()
-	receiverLimit := min(len(receivers), maxMessageHistoryNoticeReceivers)
-	receiverNames := make([]string, 0, receiverLimit)
-	for _, receiver := range receivers[:receiverLimit] {
-		receiverNames = append(receiverNames, mc.formatMessageHistoryNoticeReceiver(ctx, receiver))
-	}
-	receiverText := strings.Join(receiverNames, ", ")
-	if remainingReceivers := len(receivers) - receiverLimit; remainingReceivers > 0 {
-		otherWord := "others"
-		if remainingReceivers == 1 {
-			otherWord = "other"
-		}
-		receiverText = fmt.Sprintf("%s + %d %s", receiverText, remainingReceivers, otherWord)
-	}
 
 	sender := mc.formatMessageHistoryNoticeJID(ctx, info.Sender)
 	body := fmt.Sprintf("%s sent message history", sender)
-	if receiverText != "" {
+	if receiverText := mc.formatMessageHistoryNoticeReceivers(ctx, metadata.GetHistoryReceivers()); receiverText != "" {
 		body = fmt.Sprintf("%s to %s", body, receiverText)
 	}
 	if count := metadata.GetMessageCount(); count > 0 {

--- a/pkg/waid/dbmeta.go
+++ b/pkg/waid/dbmeta.go
@@ -61,6 +61,13 @@ func (m *UserLoginMetadata) GeneratePushKeys() {
 	}
 }
 
+func (m *UserLoginMetadata) LoadTimezone() (*time.Location, error) {
+	if m == nil || m.Timezone == "" {
+		return nil, nil
+	}
+	return time.LoadLocation(m.Timezone)
+}
+
 type MessageErrorType string
 
 const (


### PR DESCRIPTION
parse this message as "Alice sent message history to Bob, Carol + 2 others (12 messages), starting May 20, 2026 at 4:15 PM."

```protobuf
messageContextInfo {
  messageSecret: "REDACTED"
}
messageHistoryNotice {
  messageHistoryMetadata {
    historyReceivers: "15061911913891@lid"
    oldestMessageTimestampInWindow: 1778213337
    messageCount: 16
  }
}
```

fixes [PLAT-36450](https://linear.app/beeper/issue/PLAT-36450/whatsapp-parse-messagehistorynotice)

