### PR TITLE
backfill: enable aggressive deduplication

### DIFF
--- a/pkg/connector/backfill.go
+++ b/pkg/connector/backfill.go
@@ -630,6 +630,9 @@ func (wa *WhatsAppClient) convertHistorySyncMessages(
 	return &bridgev2.FetchMessagesResponse{
 		Messages: convertedMessages,
 		Cursor:   networkid.PaginationCursor(strconv.FormatUint(oldestTS, 10)),
+		// The cursor is second-granularity, so a batch boundary can split messages sharing a
+		// timestamp and re-return already-bridged ones.
+		AggressiveDeduplication: true,
 		CompleteCallback: func() {
 			// TODO this only deletes after backfilling. If there's no need for backfill after a relogin,
 			//      the messages will be stuck in the database


### PR DESCRIPTION
History sync pagination cursors are second-granularity, so a batch boundary can split a group of messages sharing a timestamp and the next page re-returns an already-bridged message, whose deterministic event ID then breaks the whole batch insert.

Set AggressiveDeduplication on history sync fetch responses so the framework drops messages that are already in the bridge database.
