### PR TITLE
Add config option to keep deleted messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v26.08 (unreleased)
+
+* Added config option to keep the Matrix copy of a sender deleted message as a
+  notice instead of removing it.
+
 # v26.07
 
 * Updated Docker image to Alpine 3.24.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-# v26.08 (unreleased)
-
-* Added config option to keep the Matrix copy of a sender deleted message as a
-  notice instead of removing it.
-
 # v26.07
 
 * Updated Docker image to Alpine 3.24.

--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -37,6 +37,7 @@ type Config struct {
 
 	CallStartNotices            bool          `yaml:"call_start_notices"`
 	IdentityChangeNotices       bool          `yaml:"identity_change_notices"`
+	KeepRevokedMessages         bool          `yaml:"keep_revoked_messages"`
 	SendPresenceOnTyping        bool          `yaml:"send_presence_on_typing"`
 	EnableStatusBroadcast       bool          `yaml:"enable_status_broadcast"`
 	DisableStatusBroadcastSend  bool          `yaml:"disable_status_broadcast_send"`
@@ -114,6 +115,7 @@ func upgradeConfig(helper up.Helper) {
 
 	helper.Copy(up.Bool, "call_start_notices")
 	helper.Copy(up.Bool, "identity_change_notices")
+	helper.Copy(up.Bool, "keep_revoked_messages")
 	helper.Copy(up.Bool, "send_presence_on_typing")
 	helper.Copy(up.Bool, "enable_status_broadcast")
 	helper.Copy(up.Bool, "disable_status_broadcast_send")

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -24,6 +24,9 @@ displayname_template: '{{or .BusinessName .PushName .Phone .RedactedPhone "Unkno
 call_start_notices: true
 # Should another user's cryptographic identity changing send a message to Matrix?
 identity_change_notices: false
+# Should the bridge keep the Matrix copy as a notice reply when the sender deletes
+# a received message on WhatsApp, instead of removing it?
+keep_revoked_messages: false
 # Should the bridge mark you as online on WhatsApp when you send typing notifications?
 # Full presence bridging is not supported.
 send_presence_on_typing: false

--- a/pkg/connector/handlewhatsapp.go
+++ b/pkg/connector/handlewhatsapp.go
@@ -36,6 +36,7 @@ import (
 	"maunium.net/go/mautrix/bridgev2/status"
 	"maunium.net/go/mautrix/event"
 
+	"go.mau.fi/mautrix-whatsapp/pkg/msgconv"
 	"go.mau.fi/mautrix-whatsapp/pkg/waid"
 )
 
@@ -408,6 +409,26 @@ func (wa *WhatsAppClient) handleWAMessage(ctx context.Context, evt *events.Messa
 		return
 	}
 
+	if parsedMessageType == "revoke" {
+		targetID := msgconv.KeyToMessageID(ctx, wa.Client, evt.Info.Chat, evt.Info.Sender, evt.Message.GetProtocolMessage().GetKey())
+		return wa.UserLogin.QueueRemoteEvent(&simplevent.Message[revokeNoticeData]{
+			EventMeta: simplevent.EventMeta{
+				Type:         bridgev2.RemoteEventMessage,
+				PortalKey:    wa.getPortalKeyByMessageSource(evt.Info.MessageSource),
+				Sender:       wa.makeEventSender(ctx, evt.Info.Sender),
+				CreatePortal: false,
+				Timestamp:    evt.Info.Timestamp,
+				StreamOrder:  evt.Info.Timestamp.Unix(),
+			},
+			Data: revokeNoticeData{
+				Text:     "Message deleted by sender (kept by bridge)",
+				TargetID: targetID,
+			},
+			ID:                 waid.MakeFakeMessageID(evt.Info.Chat, evt.Info.Sender, "revoke-"+evt.Info.ID),
+			ConvertMessageFunc: convertRevokeNotice,
+		}).Success
+	}
+
 	res := wa.UserLogin.QueueRemoteEvent(&WAMessageEvent{
 		MessageInfoWrapper: &MessageInfoWrapper{
 			OrigSource: origSource,
@@ -421,6 +442,29 @@ func (wa *WhatsAppClient) handleWAMessage(ctx context.Context, evt *events.Messa
 		dontRenderEdited:  dontRenderEdited,
 	})
 	return res.Success
+}
+
+type revokeNoticeData struct {
+	Text     string
+	TargetID networkid.MessageID
+}
+
+func convertRevokeNotice(ctx context.Context, portal *bridgev2.Portal, intent bridgev2.MatrixAPI, data revokeNoticeData) (*bridgev2.ConvertedMessage, error) {
+	content := &event.MessageEventContent{
+		MsgType: event.MsgNotice,
+		Body:    data.Text,
+	}
+	if data.TargetID != "" {
+		if msg, err := portal.Bridge.DB.Message.GetFirstPartByID(ctx, portal.Receiver, data.TargetID); err == nil && msg != nil && !msg.HasFakeMXID() {
+			content.RelatesTo = (&event.RelatesTo{}).SetReplyTo(msg.MXID)
+		}
+	}
+	return &bridgev2.ConvertedMessage{
+		Parts: []*bridgev2.ConvertedMessagePart{{
+			Type:    event.EventMessage,
+			Content: content,
+		}},
+	}, nil
 }
 
 func (wa *WhatsAppClient) handleWAUndecryptableMessage(ctx context.Context, evt *events.UndecryptableMessage) bool {

--- a/pkg/connector/handlewhatsapp.go
+++ b/pkg/connector/handlewhatsapp.go
@@ -409,7 +409,7 @@ func (wa *WhatsAppClient) handleWAMessage(ctx context.Context, evt *events.Messa
 		return
 	}
 
-	if parsedMessageType == "revoke" {
+	if parsedMessageType == "revoke" && wa.Main.Config.KeepRevokedMessages {
 		targetID := msgconv.KeyToMessageID(ctx, wa.Client, evt.Info.Chat, evt.Info.Sender, evt.Message.GetProtocolMessage().GetKey())
 		return wa.UserLogin.QueueRemoteEvent(&simplevent.Message[revokeNoticeData]{
 			EventMeta: simplevent.EventMeta{

--- a/pkg/connector/handlewhatsapp.go
+++ b/pkg/connector/handlewhatsapp.go
@@ -409,7 +409,7 @@ func (wa *WhatsAppClient) handleWAMessage(ctx context.Context, evt *events.Messa
 		return
 	}
 
-	if parsedMessageType == "revoke" && wa.Main.Config.KeepRevokedMessages {
+	if parsedMessageType == "revoke" && wa.Main.Config.KeepRevokedMessages && !evt.Info.IsFromMe {
 		targetID := msgconv.KeyToMessageID(ctx, wa.Client, evt.Info.Chat, evt.Info.Sender, evt.Message.GetProtocolMessage().GetKey())
 		return wa.UserLogin.QueueRemoteEvent(&simplevent.Message[revokeNoticeData]{
 			EventMeta: simplevent.EventMeta{


### PR DESCRIPTION
Adds `keep_revoked_messages` config option (default false).

When on messages deleted by the sender are and an `m.notice` reply `"Message deleted by sender (kept by bridge)"` instead of removing it. 

User own deletions still works as usual, the option only affects messages deleted by others.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
