### PR TITLE
connector: pace media re-requests instead of firing them in a burst

### DIFF
--- a/pkg/connector/backfill.go
+++ b/pkg/connector/backfill.go
@@ -649,14 +649,24 @@ func (wa *WhatsAppClient) convertHistorySyncMessages(
 			wa.deleteHistorySyncMessages(ctx, portalJID, newestTS, oldestTS)
 			if len(mediaRequests) > 0 {
 				go func(ctx context.Context) {
+					immediate := wa.Main.Config.HistorySync.MediaRequests.AutoRequestMedia &&
+						wa.Main.Config.HistorySync.MediaRequests.RequestMethod == MediaRequestMethodImmediate
+					sent := 0
 					for _, req := range mediaRequests {
 						err := wa.Main.DB.MediaRequest.Put(ctx, req)
 						if err != nil {
 							zerolog.Ctx(ctx).Err(err).Msg("Failed to save media request to database")
 						}
-						if wa.Main.Config.HistorySync.MediaRequests.AutoRequestMedia && wa.Main.Config.HistorySync.MediaRequests.RequestMethod == MediaRequestMethodImmediate {
-							wa.sendMediaRequest(ctx, req)
+						if !immediate {
+							continue
 						}
+						// Saved to the database above regardless, so a request that
+						// does not go out now is not lost - the daily sweep sends it.
+						if sent > 0 && !pauseBetweenMediaRequests(ctx) {
+							return
+						}
+						wa.sendMediaRequest(ctx, req)
+						sent++
 					}
 				}(context.WithoutCancel(ctx))
 			}

--- a/pkg/connector/mediarequest.go
+++ b/pkg/connector/mediarequest.go
@@ -17,6 +17,7 @@
 package connector
 
 import (
+	"math/rand/v2"
 	"context"
 	"fmt"
 	"time"
@@ -109,8 +110,30 @@ func (wa *WhatsAppClient) sendMediaRequests(ctx context.Context) {
 		return
 	}
 	zerolog.Ctx(ctx).Info().Int("request_count", len(reqs)).Msg("Sending media requests")
-	for _, req := range reqs {
+	for i, req := range reqs {
+		if i > 0 && !pauseBetweenMediaRequests(ctx) {
+			return
+		}
 		wa.sendMediaRequest(ctx, req)
+	}
+}
+
+// mediaRequestSpacing is the pause between consecutive media re-request
+// stanzas. A phone fetches expired media lazily, one item at a time, as a
+// person scrolls into a chat; it does not fire dozens of requests within a
+// millisecond right after linking. Half a second, with jitter, keeps a burst
+// of a few hundred requests spread over minutes rather than instants.
+const mediaRequestSpacing = 500 * time.Millisecond
+
+// pauseBetweenMediaRequests waits mediaRequestSpacing plus up to 50% jitter.
+// It returns false if the context ended during the wait.
+func pauseBetweenMediaRequests(ctx context.Context) bool {
+	wait := mediaRequestSpacing + time.Duration(rand.Float64()*float64(mediaRequestSpacing)*0.5)
+	select {
+	case <-time.After(wait):
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }
 


### PR DESCRIPTION
On first link of a number with real history, backfill surfaces old media whose contents have expired on the server, and every one of those became a re-request stanza fired in a tight loop — dozens to hundreds within milliseconds, immediately after the device linked, and on by default (`auto_request_media: true`, `request_method: immediate`). The once-daily sweep in `sendMediaRequests` did the same.

A phone fetches expired media one item at a time as a person scrolls into a chat; it doesn't do this. The bridge already backs off `getChatInfo` on `ErrIQRateOverLimit` a few lines away in `backfill.go`, so this reads as an inconsistency rather than a choice.

Space the requests 500 ms apart with up to 50% jitter, in both loops. Requests are saved to the database before being sent regardless, so one that does not go out in this pass is picked up by the next sweep rather than lost.

`gofmt` and `go vet` clean.