### PR TITLE
Fix/ghost profile

### DIFF
--- a/pkg/connector/userinfo.go
+++ b/pkg/connector/userinfo.go
@@ -176,7 +176,7 @@ func (wa *WhatsAppClient) doGhostResync(ctx context.Context, queue map[types.JID
 }
 
 func (wa *WhatsAppClient) GetUserInfo(ctx context.Context, ghost *bridgev2.Ghost) (*bridgev2.UserInfo, error) {
-	if ghost.Name != "" && ghost.NameSet {
+	if ghost.Name != "" && ghost.NameSet && ghost.AvatarID != "" {
 		wa.EnqueueGhostResync(ghost)
 		return nil, nil
 	}

--- a/pkg/connector/userinfo.go
+++ b/pkg/connector/userinfo.go
@@ -463,6 +463,13 @@ func (wa *WhatsAppClient) syncAltGhostWithInfo(ctx context.Context, jid types.JI
 			Msg("Failed to get ghost for alternate JID")
 		return
 	}
+
+	if ghost.AvatarID == "" {
+		altInfo := *info
+		altInfo.ExtraUpdates = bridgev2.MergeExtraUpdaters(info.ExtraUpdates, wa.fetchGhostAvatar)
+		info = &altInfo
+	}
+
 	ghost.UpdateInfo(ctx, info)
 	log.Debug().
 		Stringer("jid", jid).


### PR DESCRIPTION
### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>

Hey,

When working with the WhatsApp bridge on my Synapse homeserver I found out that some
users have no avatar in Matrix despite having one on WhatsApp. The ghost ends up with
an empty `avatar_id` and `avatar_set=true` in the DB, and the avatar never recovers,
even with logout/login and other methods.

After reading some of the code in the repo, I see that `resyncContacts` iterates
contacts by PN and decides `getAvatar` from the PN ghost. If that one already has an
avatar, the UserInfo gets no avatar fetcher, and `syncAltGhostWithInfo` hands it to
the LID ghost. `UpdateInfo` then sets `AvatarSet` on a ghost with no avatar.
`GetUserInfo` doesn't retry later either, since it returns early whenever the name is
set. since #944, as the LID ghost is the one actually in the room.

In `syncAltGhostWithInfo` I now check the alt ghost itself. If it has no avatar, I add
`fetchGhostAvatar` to the updaters, so the avatar is fetched for that ghost too. I copy
the `UserInfo` before this, because `resyncContacts` and `doGhostResync` use the same
object after the call, and I don't want to change it for them.

And in `GetUserInfo` I also check `AvatarID` before returning early, so ghosts with an
empty `AvatarID` are fetched again.

I tested it on my own server. Before the patch I had 3 ghosts in this state, all LID
ghosts, with the avatar sitting on the PN ghost. After the patch and a fresh login
there are none, and those 3 now have the same avatar IDs the PN ghosts had.